### PR TITLE
Implement swappable mold selector and memory based selector

### DIFF
--- a/examples/constant_caches.ru
+++ b/examples/constant_caches.ru
@@ -1,0 +1,37 @@
+require "pitchfork/mem_info"
+
+module App
+  CONST_NUM = Integer(ENV.fetch("NUM", 100_000))
+
+  CONST_NUM.times do |i|
+    class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+      Const#{i} = Module.new
+
+      def self.lookup_#{i}
+        Const#{i}
+      end
+    RUBY
+  end
+
+  class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+    def self.warmup
+      #{CONST_NUM.times.map { |i| "lookup_#{i}"}.join("\n")}
+    end
+  RUBY
+end
+
+run lambda { |env|
+  meminfo = Pitchfork::MemInfo.new(Process.ppid)
+  total_pss = meminfo.pss + meminfo.children.map(&:pss).sum
+  self_info = Pitchfork::MemInfo.new(Process.pid)
+
+  body = <<~EOS
+    Parent RSS: #{meminfo.rss} kiB
+       Own PSS: #{self_info.pss} kiB
+     Total PSS: #{total_pss} kiB
+  EOS
+
+  App.warmup
+
+  [ 200, { 'content-type' => 'text/plain' }, [ body ] ]
+}

--- a/examples/pitchfork.conf.minimal.rb
+++ b/examples/pitchfork.conf.minimal.rb
@@ -2,5 +2,3 @@
 
 listen 2007 # by default Pitchfork listens on port 8080
 worker_processes 4 # this should be >= nr_cpus
-stderr_path "/path/to/app/shared/log/pitchfork.log"
-stdout_path "/path/to/app/shared/log/pitchfork.log"

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -150,8 +150,8 @@ end
 # :enddoc:
 
 %w(
-  const socket_helper stream_input tee_input children message http_request
-  configurator tmpio util http_response worker http_server
+  const socket_helper stream_input tee_input mem_info children message http_request
+  mold_selector configurator tmpio util http_response worker http_server
 ).each do |s|
   require_relative "pitchfork/#{s}"
 end

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -75,6 +75,14 @@ module Pitchfork
       @workers.values
     end
 
+    def fresh_workers
+      if @mold
+        workers.select { |w| w.generation >= @mold.generation }
+      else
+        workers
+      end
+    end
+
     def workers_count
       @workers.size
     end

--- a/lib/pitchfork/mem_info.rb
+++ b/lib/pitchfork/mem_info.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Pitchfork
+  class MemInfo
+    attr_reader :rss, :pss, :shared_memory
+
+    def initialize(pid)
+      @pid = pid
+      update
+    end
+
+    def children
+      File.read("/proc/#{@pid}/task/#{@pid}/children").split.map { |pid| MemInfo.new(pid) }
+    end
+
+    def cow_efficiency(parent_meminfo)
+      shared_memory.to_f / parent_meminfo.rss * 100.0
+    end
+
+    def update
+      info = parse(File.read("/proc/#{@pid}/smaps_rollup"))
+      @pss = info.fetch(:Pss)
+      @rss = info.fetch(:Rss)
+      @shared_memory = info.fetch(:Shared_Clean) + info.fetch(:Shared_Dirty)
+      self
+    end
+
+    private
+
+    def parse(rollup)
+      fields = {}
+      rollup.each_line do |line|
+        if (matchdata = line.match(/(?<field>\w+)\:\s+(?<size>\d+) kB$/))
+          fields[matchdata[:field].to_sym] = matchdata[:size].to_i
+        end
+      end
+      fields
+    end
+  end
+end

--- a/lib/pitchfork/mold_selector.rb
+++ b/lib/pitchfork/mold_selector.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Pitchfork
+  module MoldSelector
+    class Base
+      def initialize(children)
+        @children = children
+      end
+    end
+
+    def select(_logger)
+      raise NotImplementedError, "Must implement #select"
+    end
+
+    class LeastSharedMemory < Base
+      def select(logger)
+        workers = @children.fresh_workers
+        if workers.empty?
+          logger.info("No current generation workers yet")
+          return
+        end
+        candidate = workers.shift
+        candidate_meminfo = MemInfo.new(candidate.pid)
+
+        workers.each do |worker|
+          worker_meminfo = MemInfo.new(worker.pid)
+          if worker_meminfo.shared_memory < candidate_meminfo.shared_memory
+            # We suppose that a worker with a lower amount of shared memory
+            # has warmed up more caches & such, hence is closer to stabilize
+            # making it a better candidate.
+            candidate, candidate_meminfo = worker, worker_meminfo
+          end
+        end
+        parent_meminfo = MemInfo.new(@children.mold&.pid || Process.pid)
+        cow_efficiency = candidate_meminfo.cow_efficiency(parent_meminfo)
+        logger.info("worker=#{candidate.nr} pid=#{candidate.pid} selected as new mold shared_memory_kb=#{candidate_meminfo.shared_memory} cow=#{cow_efficiency.round(1)}%")
+        candidate
+      end
+    end
+  end
+end


### PR DESCRIPTION
The memory metrics are gathered through `/proc/smap_rollups` which is linux only, but so is CHILD_SUBREAPER.