### PR TITLE
WIP: Automatic refork based on total memory usage

### DIFF
--- a/examples/constant_caches.ru
+++ b/examples/constant_caches.ru
@@ -22,7 +22,14 @@ end
 
 run lambda { |env|
   meminfo = Pitchfork::MemInfo.new(Process.ppid)
-  total_pss = meminfo.pss + meminfo.children.map(&:pss).sum
+  siblings_pids = File.read("/proc/#{Process.ppid}/task/#{Process.ppid}/children").split
+  siblings = siblings_pids.map do |pid|
+    Pitchfork::MemInfo.new(pid)
+  rescue Errno::ENOENT # The process just died
+    nil
+  end.compact
+
+  total_pss = meminfo.pss + siblings.map(&:pss).sum
   self_info = Pitchfork::MemInfo.new(Process.pid)
 
   body = <<~EOS

--- a/examples/echo.ru
+++ b/examples/echo.ru
@@ -1,5 +1,3 @@
-#\-E none
-#
 # Example application that echoes read data back to the HTTP client.
 # This emulates the old echo protocol people used to run.
 #

--- a/examples/hello.ru
+++ b/examples/hello.ru
@@ -1,6 +1,5 @@
-#\-E none
-#
 run lambda { |env|
   /\A100-continue\z/i =~ env['HTTP_EXPECT'] and return [100, {}, []]
-  [ 200, { 'content-type' => 'application/octet-stream' }, [ "Hello World!\n" ] ]
+  body = "Hello World!\n"
+  [ 200, { 'content-type' => 'text/plain', 'content-length' => body.bytesize.to_s }, [ body ] ]
 }

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -151,7 +151,7 @@ end
 
 %w(
   const socket_helper stream_input tee_input mem_info children message http_request
-  mold_selector configurator tmpio util http_response worker http_server
+  refork_condition mold_selector configurator tmpio util http_response worker http_server
 ).each do |s|
   require_relative "pitchfork/#{s}"
 end

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -14,6 +14,7 @@ module Pitchfork
       @molds = {} # Molds, index by PID.
       @mold = nil # The latest mold, if any.
       @pending_workers = {} # Pending workers indexed by their `nr`.
+      @pending_molds = {} # Worker promoted to mold, not yet acknowledged
     end
 
     def refresh
@@ -38,6 +39,7 @@ module Pitchfork
 
       if child.mold?
         @workers.delete(old_nr)
+        @pending_molds.delete(child.pid)
         @molds[child.pid] = child
         @mold = child
       end
@@ -55,6 +57,7 @@ module Pitchfork
     def reap(pid)
       if child = @children.delete(pid)
         @pending_workers.delete(child.nr)
+        @pending_molds.delete(child.nr)
         @molds.delete(child.pid)
         @workers.delete(child.nr)
         if @mold == child
@@ -64,8 +67,13 @@ module Pitchfork
       child
     end
 
+    def promote(worker)
+      @pending_molds[worker.pid] = worker
+      worker.promote(self.last_generation += 1)
+    end
+
     def pending_workers?
-      !@pending_workers.empty?
+      !(@pending_workers.empty? && @pending_molds.empty?)
     end
 
     def molds
@@ -90,6 +98,14 @@ module Pitchfork
 
     def workers_count
       @workers.size
+    end
+
+    def total_pss
+      total_pss = MemInfo.new(Process.pid).pss
+      @children.each do |_, worker|
+        total_pss += worker.meminfo.pss if worker.meminfo
+      end
+      total_pss
     end
   end
 end

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -57,6 +57,7 @@ module Pitchfork
         },
       :early_hints => false,
       :mold_selector => MoldSelector::LeastSharedMemory,
+      :refork_condition => ReforkCondition::MaxMemory.new(500_000_000),
       :check_client_connection => false,
       :rewindable_input => true,
       :client_body_buffer_size => Pitchfork::Const::MAX_BODY,

--- a/lib/pitchfork/mem_info.rb
+++ b/lib/pitchfork/mem_info.rb
@@ -9,10 +9,6 @@ module Pitchfork
       update
     end
 
-    def children
-      File.read("/proc/#{@pid}/task/#{@pid}/children").split.map { |pid| MemInfo.new(pid) }
-    end
-
     def cow_efficiency(parent_meminfo)
       shared_memory.to_f / parent_meminfo.rss * 100.0
     end

--- a/lib/pitchfork/mold_selector.rb
+++ b/lib/pitchfork/mold_selector.rb
@@ -6,10 +6,10 @@ module Pitchfork
       def initialize(children)
         @children = children
       end
-    end
 
-    def select(_logger)
-      raise NotImplementedError, "Must implement #select"
+      def select(_logger)
+        raise NotImplementedError, "Must implement #select"
+      end
     end
 
     class LeastSharedMemory < Base

--- a/lib/pitchfork/refork_condition.rb
+++ b/lib/pitchfork/refork_condition.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pitchfork
+  module ReforkCondition
+    class MaxMemory
+      def initialize(max_memory)
+        @cutoff = max_memory / 1000.0 # convert to kB
+      end
+
+      def met?(children, logger)
+        children.total_pss > @cutoff
+      end
+    end
+  end
+end


### PR DESCRIPTION
Opening as a WIP PR because I think I need to take a step back on the automatic refork condition.

Here we look at the overall memory usage, and if it's past a threshold, we trigger a refork. It works as desired, but after experimenting with it, I think a memory limit might be too hard to use effectively and it doesn't degrade well.

If you configure it too low and that even after reforking we're past that limit, we'll just constantly refork workers which isn't desirable. You might think that it's just a matter of configuring properly, but it's too easy to get wrong, and the degraded mode is too broken for my taste.

I also don't see a way to make the difference between memory that should be shared and isn't, and memory that just can't be shared (the memory used to process the current request).

If we could compact memory and trim it when promoting workers, we could have an idea, but unfortunately we can't.

So I'm thinking that it may be preferable to use another metric:

  - Request count: we could refork after every X requests. Simple, predictable. We could even exponentially refork less frequently.
  - Age: we could refork after every X seconds / minutes. Simple too, however if utilization is lower it might lead to different results.

