### PR TITLE
Automatic refork based on number of processed requests

### DIFF
--- a/examples/pitchfork.conf.minimal.rb
+++ b/examples/pitchfork.conf.minimal.rb
@@ -2,3 +2,4 @@
 
 listen 2007 # by default Pitchfork listens on port 8080
 worker_processes 4 # this should be >= nr_cpus
+refork_after 50, 100, 1000

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -151,7 +151,7 @@ end
 
 %w(
   const socket_helper stream_input tee_input mem_info children message http_request
-  mold_selector configurator tmpio util http_response worker http_server
+  refork_condition mold_selector configurator tmpio util http_response worker http_server
 ).each do |s|
   require_relative "pitchfork/#{s}"
 end

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -57,6 +57,7 @@ module Pitchfork
         },
       :early_hints => false,
       :mold_selector => MoldSelector::LeastSharedMemory,
+      :refork_condition => nil,
       :check_client_connection => false,
       :rewindable_input => true,
       :client_body_buffer_size => Pitchfork::Const::MAX_BODY,
@@ -548,6 +549,15 @@ module Pitchfork
     # It is safe to point this to the same location a stderr_path.
     def stdout_path(path)
       set_path(:stdout_path, path)
+    end
+
+    # Defines the number of requests per-worker after which a new generation
+    # should be spawned.
+    #
+    # example:
+    #.  refork_after 50, 100, 1000
+    def refork_after(*limits)
+      set[:refork_condition] = ReforkCondition::RequestsCount.new(*limits)
     end
 
     # expands "unix:path/to/foo" to a socket relative to the current path

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -18,7 +18,7 @@ module Pitchfork
                   :listener_opts,
                   :orig_app, :config, :ready_pipe,
                   :default_middleware, :early_hints
-    attr_writer   :after_worker_exit, :after_worker_ready
+    attr_writer   :after_worker_exit, :after_worker_ready, :refork_condition
 
     attr_reader :logger
     include Pitchfork::SocketHelper
@@ -33,6 +33,9 @@ module Pitchfork
 
     # listeners we have yet to bind
     NEW_LISTENERS = []
+
+    REFORKING_AVAILABLE = ChildSubreaper::AVAILABLE || Process.pid == 1
+    MAX_SLEEP = 1 # seconds
 
     # :startdoc:
     # This Hash is considered a stable interface and changing its contents
@@ -252,7 +255,7 @@ module Pitchfork
         end
         if @respawn
           maintain_worker_count
-          shutdown_outdated_workers
+          automatically_refork_workers if REFORKING_AVAILABLE
         end
 
         master_sleep(sleep_time) if sleep
@@ -267,16 +270,7 @@ module Pitchfork
         logger.info "master done reopening logs"
         soft_kill_each_worker(:USR1)
       when :USR2 # trigger a promotion
-        if Process.pid == 1 || ChildSubreaper::AVAILABLE
-          @children.refresh
-          if new_mold = @mold_selector.select(logger)
-            new_mold.promote(@children.last_generation += 1)
-          else
-            logger.error("The mold select didn't return a candidate")
-          end
-        else
-          logger.error("This system doesn't support PR_SET_CHILD_SUBREAPER, no point promoting a worker")
-        end
+        trigger_refork
       when :TTIN
         @respawn = true
         self.worker_processes += 1
@@ -350,6 +344,8 @@ module Pitchfork
 
     # wait for a signal hander to wake us up and then consume the pipe
     def master_sleep(sec)
+      sec = MAX_SLEEP if sec > MAX_SLEEP
+
       @control_socket[0].wait(sec) or return
       case message = @control_socket[0].recvmsg_nonblock(exception: false)
       when :wait_readable, NOOP
@@ -420,6 +416,22 @@ module Pitchfork
         kill_worker(:KILL, worker.pid) # take no prisoners for timeout violations
       end
       next_sleep <= 0 ? 1 : next_sleep
+    end
+
+    def trigger_refork
+      unless REFORKING_AVAILABLE
+        logger.error("This system doesn't support PR_SET_CHILD_SUBREAPER, can't promote a worker")
+      end
+
+      unless @children.pending_promotion?
+        @children.refresh
+        if new_mold = @mold_selector.select(logger)
+          @children.promote(new_mold)
+        else
+          logger.error("The mold select didn't return a candidate")
+        end
+      else
+      end
     end
 
     def after_fork_internal
@@ -503,20 +515,34 @@ module Pitchfork
       @children.each_worker { |w| w.nr >= worker_processes and w.soft_kill(:QUIT) }
     end
 
-    def shutdown_outdated_workers
-      return unless @children.mold
+    def automatically_refork_workers
+      # If we're already in the middle of forking a new generation, we just continue
+      if @children.mold
+        # We don't shutdown any outdated worker if any worker is already being spawed
+        # or a worker is exiting. Workers are only reforked one by one to minimize the
+        # impact on capacity.
+        # In the future we may want to use a dynamic limit, e.g. 10% of workers may be down at
+        # a time.
+        return if @children.pending_workers?
+        return if @children.workers.any?(&:exiting?)
 
-      # We don't shutdown any outdated worker if any worker is already being spawed
-      # or a worker is exiting. Workers are only reforked one by one to minimize the
-      # impact on capacity.
-      # In the future we may want to use a dynamic limit, e.g. 10% of workers may be down at
-      # a time.
-      return if @children.pending_workers?
-      return if @children.workers.any?(&:exiting?)
+        if outdated_worker = @children.workers.find { |w| w.generation < @children.mold.generation }
+          logger.info("worker=#{outdated_worker.nr} pid=#{outdated_worker.pid} restarting")
+          outdated_worker.soft_kill(:QUIT)
+          return # That's all folks
+        end
+      end
 
-      if outdated_worker = @children.workers.find { |w| w.generation < @children.mold.generation }
-        logger.info("worker=#{outdated_worker.nr} pid=#{outdated_worker.pid} restarting")
-        outdated_worker.soft_kill(:QUIT)
+      # If all workers are alive and well, we can consider reforking a new generation
+      if @refork_condition
+        @children.refresh
+        if @refork_condition.met?(@children, logger)
+          logger.info("Refork condition met, scheduling a promotion")
+          unless @sig_queue.include?(:USR2)
+            @sig_queue << :USR2
+            awaken_master
+          end
+        end
       end
     end
 

--- a/lib/pitchfork/refork_condition.rb
+++ b/lib/pitchfork/refork_condition.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Pitchfork
+  module ReforkCondition
+    class RequestsCount
+      def initialize(*request_counts)
+        @limits = request_counts.flatten
+      end
+
+      def met?(children, logger)
+        if limit = @limits[children.last_generation]
+          if worker = children.fresh_workers.find { |w| w.requests_count >= limit }
+            logger.info("worker=#{worker.nr} pid=#{worker.pid} processed #{worker.requests_count} requests, triggering a refork")
+            return true
+          end
+        end
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/Shopify/pitchfork/pull/3

This is expected to be more predictable than memory metrics.

The refork happens once one worker processed the provided amount of requests.

Workers are expected to stabilize after a while, so there is little point reforking constantly. As time goes, you want to refork exponentially less often.