### PR TITLE
Boot the app in an initial mold rather than in the master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM ruby:3.1
-RUN apt-get update -y && apt-get install -y ragel socat netcat smem
+RUN apt-get update -y && apt-get install -y ragel socat netcat smem apache2-utils
 WORKDIR /app
 CMD [ "bash" ]

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ namespace :test do
           sh("rm", "-rf", "trash")
           sh("mkdir", "trash")
           command = ["sh", integration_test]
-          command << "-v" if ENV["VERBOSE"]
+          command << "-v" if ENV["VERBOSE"] || ENV["CI"]
           sh(*command)
         end
       end

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -31,6 +31,8 @@ module Pitchfork
   # not rescue it explicitly, but rescue EOFError instead.
   ClientShutdown = Class.new(EOFError)
 
+  BootFailure = Class.new(StandardError)
+
   # :stopdoc:
 
   # This returns a lambda to pass in as the app, this does not "build" the

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -27,6 +27,12 @@ module Pitchfork
       @pending_workers[child.nr] = @workers[child.nr] = child
     end
 
+    def register_mold(mold)
+      @pending_molds[mold.pid] = mold
+      @children[mold.pid] = mold
+      @mold = mold
+    end
+
     def fetch(pid)
       @children.fetch(pid)
     end
@@ -57,7 +63,7 @@ module Pitchfork
     def reap(pid)
       if child = @children.delete(pid)
         @pending_workers.delete(child.nr)
-        @pending_molds.delete(child.nr)
+        @pending_molds.delete(child.pid)
         @molds.delete(child.pid)
         @workers.delete(child.nr)
         if @mold == child

--- a/test/unit/test_ccc.rb
+++ b/test/unit/test_ccc.rb
@@ -84,7 +84,9 @@ class TestCccTCPI < Minitest::Test
     if pid
       Process.kill(:QUIT, pid)
       _, status = Process.waitpid2(pid)
-      assert status.success?
+      unless $!
+        assert_predicate status, :success?
+      end
     end
     err.close! if err
     rd.close if rd

--- a/test/unit/test_children.rb
+++ b/test/unit/test_children.rb
@@ -67,5 +67,17 @@ module Pitchfork
       assert_nil @children.mold
       assert_equal [], @children.molds
     end
+
+    def test_reap_pending_mold
+      mold = Worker.new(nil)
+      @children.register_mold(mold)
+      assert_predicate @children, :pending_workers?
+
+      assert_equal mold, @children.reap(mold.pid)
+      refute_predicate @children, :pending_workers?
+      assert_nil @children.mold
+      assert_equal [], @children.molds
+      assert_nil @children.reap(mold.pid)
+    end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/pitchfork/issues/6

Since the master never executes the vast majority of codepaths it is just wasting memory that can't possibly be shared.

The downside is that loading inside an initial mold is a bit more involved.

Co-Authored-By: @paarthmadan 

(opening as a draft to resume the work on this)