### PR TITLE
Remove log reopening on USR1 and `stderr_path` / `stdout_path` configs

### DIFF
--- a/examples/pitchfork.conf.rb
+++ b/examples/pitchfork.conf.rb
@@ -12,11 +12,6 @@ listen 8080, :tcp_nopush => true
 # nuke workers after 30 seconds instead of 60 seconds (the default)
 timeout 30
 
-# By default, the Pitchfork logger will write to stderr.
-# Additionally, ome applications/frameworks log to stderr or stdout.
-stderr_path "/path/to/app/shared/log/pitchfork.stderr.log"
-stdout_path "/path/to/app/shared/log/pitchfork.stdout.log"
-
 # Enable this flag to have pitchfork test client connections by writing the
 # beginning of the HTTP headers before calling the application.  This
 # prevents calling the application for connections that have disconnected

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -108,7 +108,6 @@ module Pitchfork
       # list of signals we care about and trap in master.
       @queue_sigs = [
         :QUIT, :INT, :TERM, :USR2, :TTIN, :TTOU ]
-
       Worker.preallocate_drops(worker_processes)
     end
 
@@ -176,9 +175,6 @@ module Pitchfork
 
       (set_names - cur_names).each { |addr| listen(addr) }
     end
-
-    def stdout_path=(path); redirect_io($stdout, path); end
-    def stderr_path=(path); redirect_io($stderr, path); end
 
     def logger=(obj)
       Pitchfork::HttpRequest::DEFAULTS["rack.logger"] = @logger = obj
@@ -415,9 +411,9 @@ module Pitchfork
         end
         next_sleep = 0
         if worker.mold?
-          logger.error "mold PID:#{worker.pid} timeout (#{diff}s > #{@timeout}s), killing"
+          logger.error "mold pid=#{worker.pid} timeout (#{diff}s > #{@timeout}s), killing"
         else
-          logger.error "worker=#{worker.nr} PID:#{worker.pid} timeout (#{diff}s > #{@timeout}s), killing"
+          logger.error "worker=#{worker.nr} pid=#{worker.pid} timeout (#{diff}s > #{@timeout}s), killing"
         end
         kill_worker(:KILL, worker.pid) # take no prisoners for timeout violations
       end
@@ -819,11 +815,6 @@ module Pitchfork
     def proc_name(tag)
       $0 = ([ File.basename(START_CTX[0]), tag
             ]).concat(START_CTX[:argv]).join(' ')
-    end
-
-    def redirect_io(io, path)
-      File.open(path, 'ab') { |fp| io.reopen(fp) } if path
-      io.sync = true
     end
 
     def inherit_listeners!

--- a/test/integration/t0006.ru
+++ b/test/integration/t0006.ru
@@ -2,12 +2,8 @@ use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env|
 
-  # our File objects for stderr/stdout should always have #path
-  # and be sync=true
-  ok = $stderr.sync &&
-       $stdout.sync &&
-       String === $stderr.path &&
-       String === $stdout.path
+  # our File objects for stderr/stdout should always be sync=true
+  ok = $stderr.sync && $stdout.sync
 
   [ 200, {}, [ "#{ok}\n" ] ]
 }

--- a/test/integration/t0010-reap-logging.sh
+++ b/test/integration/t0010-reap-logging.sh
@@ -23,9 +23,8 @@ t_begin "wait for 2nd worker to start" && {
 
 t_begin "ensure log of 1st reap is an ERROR" && {
 	dbgcat r_err
-	grep 'ERROR.*worker=0.*reaped' $r_err | grep $pid_1
+	grep "ERROR.*worker=0 pid=$pid_1 .*reaped" $r_err
 	dbgcat r_err
-	> $r_err
 }
 
 t_begin "kill 2nd worker gracefully" && {
@@ -38,7 +37,7 @@ t_begin "wait for 3rd worker=0 to start " && {
 }
 
 t_begin "ensure log of 2nd reap is a INFO" && {
-	grep 'INFO.*worker=0.*reaped' $r_err | grep $pid_2
+	grep "INFO.*worker=0.*pid=$pid_2 .*reaped" $r_err
 	> $r_err
 }
 

--- a/test/integration/test-lib.sh
+++ b/test/integration/test-lib.sh
@@ -113,8 +113,6 @@ pitchfork_setup () {
 	rtmpfiles pitchfork_config pid r_err r_out fifo tmp ok
 	cat > $pitchfork_config <<EOF
 listen "$listen"
-stderr_path "$r_err"
-stdout_path "$r_out"
 EOF
 }
 
@@ -154,7 +152,7 @@ wait_for_service() {
 
 pitchfork_spawn () {
 	(
-		pitchfork "$@" &
+		pitchfork "$@" 2>"$r_err" 1>"$r_out" &
 		echo "$!" > "$pid"
 	) &
 	wait

--- a/test/unit/test_ccc.rb
+++ b/test/unit/test_ccc.rb
@@ -11,7 +11,6 @@ class TestCccTCPI < Minitest::Test
     host = '127.0.0.1'
     srv = TCPServer.new(host, 0)
     port = srv.addr[1]
-    err = Tempfile.new('pitchfork_ccc')
     rd, wr = IO.pipe
     sleep_pipe = IO.pipe
     pid = fork do
@@ -34,7 +33,6 @@ class TestCccTCPI < Minitest::Test
       ENV['UNICORN_FD'] = srv.fileno.to_s
       opts = {
         listeners: [ "#{host}:#{port}" ],
-        stderr_path: err.path,
         worker_processes: 1,
         check_client_connection: true,
       }
@@ -88,7 +86,6 @@ class TestCccTCPI < Minitest::Test
         assert_predicate status, :success?
       end
     end
-    err.close! if err
     rd.close if rd
   end
 end


### PR DESCRIPTION
Log re-opening, like daemonization and re-exec is useful for traditional deployments on a long lived host, with log rotation etc.

`pitchfork` is designed and optimized for more modern deployment such as containers or systemd where these concerns are handled without having to re-open logs.

It's best to log to STDERR / STDOUT [like a 12 factor app](https://12factor.net/logs)