### PR TITLE
Rework test to avoid using invalid status code

### DIFF
--- a/test/integration/fails-rack-lint.ru
+++ b/test/integration/fails-rack-lint.ru
@@ -1,5 +1,5 @@
-# This rack app returns an invalid status code, which will cause
+# This rack app returns a header with key named "status", which will cause
 # Rack::Lint to throw an exception if it is present.  This
 # is used to check whether Rack::Lint is in the stack or not.
 
-run lambda {|env| return [42, {}, ["Rack::Lint wasn't there if you see this"]]}
+run lambda {|env| return [200, { "status" => "fails-rack-lint"}, ["Rack::Lint wasn't there if you see this\n"]]}

--- a/test/integration/t0300-no-default-middleware.sh
+++ b/test/integration/t0300-no-default-middleware.sh
@@ -9,7 +9,7 @@ t_begin "setup and start" && {
 }
 
 t_begin "check exit status with Rack::Lint not present" && {
-	test 42 -eq "$(curl -sf -o/dev/null -w'%{http_code}' http://$listen/)"
+	test 200 -eq "$(curl -sf -o/dev/null -w'%{http_code}' http://$listen/)"
 }
 
 t_begin "killing succeeds" && {


### PR DESCRIPTION
Closes #19

For a reason I haven't conclusively determined, in the CI environment this particular test no longer works. I have a few hunches, but thought I'd ship this fix first.

This fix essentially restructures the same test behaviour (which is to create a violation for `Rack::Lint` and assert that a 200 is returned when default middleware is disabled).

Instead of relying on an invalid HTTP code, [it creates a different violation: including `status` in the headers list.](https://github.com/rack/rack/blob/8e280992ac43b73eb0e8c75f8c68784bb7f23390/lib/rack/lint.rb#L647-L648)

My suspicion is that the Github runner's version of cURL doesn't play nicely with invalid HTTP status codes (<100). I half-confirmed this because on various runs with different status codes, the CI environment would successfully poll the code albeit fail because it wasn't what was expected, i.e 42. Only in the instances when the stubbed code was less than 100 did the HTTP code resolve to 0.

I'll follow up with the root-cause because I'm interested, but this patch maintains functionality and fixes master.

I also confirmed that we see the `Rack::Lint` error both in CI and locally when the `-N` flag isn't passed into pitchfork.