### PR TITLE
Leverage Ruby's ALLOCV to save allocating in get_readers

### DIFF
--- a/ext/pitchfork_http/epollexclusive.h
+++ b/ext/pitchfork_http/epollexclusive.h
@@ -90,8 +90,7 @@ get_readers(VALUE epio, VALUE ready, VALUE readers, VALUE timeout_msec)
 	Check_Type(ready, T_ARRAY);
 	Check_Type(readers, T_ARRAY);
 	epw.maxevents = RARRAY_LENINT(readers);
-	buf = rb_str_buf_new(sizeof(struct epoll_event) * epw.maxevents);
-	epw.events = (struct epoll_event *)RSTRING_PTR(buf);
+	epw.events = RB_ALLOCV_N(struct epoll_event, buf, epw.maxevents);
 	epio = rb_io_get_io(epio);
 	GetOpenFile(epio, epw.fptr);
 
@@ -109,7 +108,6 @@ get_readers(VALUE epio, VALUE ready, VALUE readers, VALUE timeout_msec)
 		if (RTEST(obj))
 			rb_ary_push(ready, obj);
 	}
-	rb_str_resize(buf, 0);
 	return Qfalse;
 }
 #endif /* USE_EPOLL */


### PR DESCRIPTION
Inspired by: https://yhbt.net/unicorn-public/20230301231205.M669849@dcvr/#R

It was introduced in Ruby 1.9 https://github.com/ruby/ruby/commit/8489ac41cadc1ef80ea57799bc833a831d1afdc6

> Allocates a  memory region, possibly  on stack.   If the given  size exceeds
> #RUBY_ALLOCV_LIMIT, it allocates a dedicated  opaque ruby object instead and
> let our GC sweep that region after use.  Either way you can fire-and-forget.

Currently RUBY_ALLOCV_LIMIT is defined as 1kB, `struct epoll_event` seem to be 12B on x86_64, so we'd only allocate if we need over 85 readers, which seem improbable.