### PR TITLE
Refork indefinitely when `refork_after` is set, unless the last element is `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Refork indefinitely when `refork_after` is set, unless the last element is `false`.
 - Remove `mold_selector`. The promotion logic has been moved inside workers (#38).
 - Add the `after_promotion` callback.
 - Removed the `before_fork` callback.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -322,8 +322,14 @@ once at least one worker processed `50` requests.
 
 Each element is a limit for the next generation. On the example above a new generation
 is triggered when a worker has processed 50 requests, then the second generation when
-a worker from the new generation processed an additional 100 requests and finally after another
+a worker from the new generation processed an additional 100 requests and finally after *every*
 1000 requests.
+
+If you don't want unlimited reforking, you can set `false` as the last element of the array:
+
+```ruby
+refork_after [50, 100, 1000, false]
+```
 
 Generally speaking Copy-on-Write efficiency tend to degrade fast during the early requests,
 and then less and less frequently.

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -203,8 +203,12 @@ module Pitchfork
     # Defines the number of requests per-worker after which a new generation
     # should be spawned.
     #
+    # +false+ can be used to mark a final generation, otherwise the last request
+    # count is re-used indefinitely.
+    #
     # example:
     #.  refork_after [50, 100, 1000]
+    #.  refork_after [50, 100, 1000, false]
     #
     # Note that reforking is only available on Linux. Other Unix-like systems
     # don't have this capability.

--- a/lib/pitchfork/refork_condition.rb
+++ b/lib/pitchfork/refork_condition.rb
@@ -8,7 +8,7 @@ module Pitchfork
       end
 
       def met?(worker, logger)
-        if limit = @limits[worker.generation]
+        if limit = @limits.fetch(worker.generation) { @limits.last }
           if worker.requests_count >= limit
             logger.info("worker=#{worker.nr} pid=#{worker.pid} processed #{worker.requests_count} requests, triggering a refork")
             return true

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -183,8 +183,8 @@ module Pitchfork
       @requests_count = 0
     end
 
-    def increment_requests_count
-      @requests_count += 1
+    def increment_requests_count(by = 1)
+      @requests_count += by
     end
 
     # called in both the master (reaping worker) and worker (SIGQUIT handler)

--- a/test/unit/test_refork_condition.rb
+++ b/test/unit/test_refork_condition.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module Pitchfork
+  class TestReforkCondition < Pitchfork::Test
+    def setup
+      @logger = Logger.new(nil)
+      @worker = Worker.new(0, pid: 42)
+    end
+
+    def test_requests_count_repeat
+      @condition = ReforkCondition::RequestsCount.new([10, 50])
+
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(11)
+      assert @condition.met?(@worker, @logger)
+
+      @worker.promote!
+      @worker.reset
+
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(11)
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(40)
+      assert @condition.met?(@worker, @logger)
+
+      @worker.promote!
+      @worker.reset
+
+      @worker.increment_requests_count(49)
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(1)
+      assert @condition.met?(@worker, @logger)
+    end
+
+    def test_requests_count_stop
+      @condition = ReforkCondition::RequestsCount.new([10, nil])
+
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(11)
+      assert @condition.met?(@worker, @logger)
+
+      @worker.promote!
+      @worker.reset
+
+      refute @condition.met?(@worker, @logger)
+      @worker.increment_requests_count(50)
+      refute @condition.met?(@worker, @logger)
+    end
+  end
+end


### PR DESCRIPTION
Generally speaking, even when the app is warmed up, you'll want to continue reforking periodically, just less often.

`after_promotion` is also a perfect hook for OOBGC & co.