### PR TITLE
Backoff for 10s after any old spawning attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Backoff 10s after every mold spawning attempt.
 - Spawn mold from workers instead of promoting workers (#42).
 
 # 0.2.0

--- a/lib/pitchfork/refork_condition.rb
+++ b/lib/pitchfork/refork_condition.rb
@@ -5,16 +5,34 @@ module Pitchfork
     class RequestsCount
       def initialize(request_counts)
         @limits = request_counts
+        @backoff_until = nil
       end
 
       def met?(worker, logger)
         if limit = @limits.fetch(worker.generation) { @limits.last }
           if worker.requests_count >= limit
+            return false if backoff?
+
             logger.info("worker=#{worker.nr} pid=#{worker.pid} processed #{worker.requests_count} requests, triggering a refork")
             return true
           end
         end
         false
+      end
+
+      def backoff?
+        return false if @backoff_until.nil?
+
+        if @backoff_until > Pitchfork.time_now
+          true
+        else
+          @backoff_until = nil
+          false
+        end
+      end
+
+      def backoff!(delay = 10.0)
+        @backoff_until = Pitchfork.time_now + delay
       end
     end
   end

--- a/test/unit/test_refork_condition.rb
+++ b/test/unit/test_refork_condition.rb
@@ -46,5 +46,15 @@ module Pitchfork
       @worker.increment_requests_count(50)
       refute @condition.met?(@worker, @logger)
     end
+
+    def test_backoff
+      @condition = ReforkCondition::RequestsCount.new([10, nil])
+      @worker.increment_requests_count(11)
+      assert @condition.met?(@worker, @logger)
+
+      @condition.backoff!
+
+      refute @condition.met?(@worker, @logger)
+    end
   end
 end


### PR DESCRIPTION
Whether we failed or not, it means a mold is already being spawned so we should give it time to be ready. Otherwise we'll just hammer the lock after every request for no reason.