### PR TITLE
Rename `after_promotion` in `after_mold_fork` and `after_fork` in `after_worker_fork`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Renamed `after_promotion` in `after_mold_fork`.
+- Renamed `after_fork` in `after_worker_fork`.
 - Backoff 10s after every mold spawning attempt.
 - Spawn mold from workers instead of promoting workers (#42).
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -28,7 +28,7 @@
 
 * Configuration is purely in Ruby. Ruby is less
   ambiguous than YAML and lets lambdas for
-  before_fork/after_fork hooks be defined inline. An
+  after_worker_fork/after_mold_fork hooks be defined inline. An
   optional, separate config_file may be used to modify supported
   configuration changes.
 

--- a/docs/FORK_SAFETY.md
+++ b/docs/FORK_SAFETY.md
@@ -12,16 +12,21 @@ end up shared between the parent and child process. This is never what you
 want, so any code keeping persistent connections should close them either
 before or after the fork happens.
 
-`pitchfork` provide two callbacks in its configuration file to do so:
+Most modern Ruby libraries automatically handle this, it's the case of
+Active Record, redis-rb, dalli, net-http-persistent, etc.
+
+However, for libraries that aren't automatically fork-safe
+`pitchfork` provide two callbacks in its configuration file to manually
+reopen connections and restart threads:
 
 ```ruby
 # pitchfork.conf.rb
 
-before_fork do
+after_mold_fork do
   Sequel::DATABASES.each(&:disconnect)
 end
 
-after_fork do
+after_worker_fork do
   SomeLibary.connection.close
 end
 ```

--- a/examples/pitchfork.conf.rb
+++ b/examples/pitchfork.conf.rb
@@ -23,12 +23,7 @@ check_client_connection false
 # local variable to guard against running a hook multiple times
 run_once = true
 
-after_promotion do |server, worker|
-  # the following is highly recommended for Rails
-  # as there's no need for the mold process to hold a connection
-  defined?(ActiveRecord::Base) and
-    ActiveRecord::Base.connection.disconnect!
-
+after_mold_fork do |server, mold|
   # Occasionally, it may be necessary to run non-idempotent code in the
   # master before forking.  Keep in mind the above disconnect! example
   # is idempotent and does not need a guard.
@@ -37,41 +32,8 @@ after_promotion do |server, worker|
     run_once = false # prevent from firing again
   end
 
-  # The following is only recommended for memory/DB-constrained
-  # installations.  It is not needed if your system can house
-  # twice as many worker_processes as you have configured.
-  #
-  # # This allows a new master process to incrementally
-  # # phase out the old master process with SIGTTOU to avoid a
-  # # thundering herd
-  # # when doing a transparent upgrade.  The last worker spawned
-  # # will then kill off the old master process with a SIGQUIT.
-  # old_pid = "#{server.config[:pid]}.oldbin"
-  # if old_pid != server.pid
-  #   begin
-  #     sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
-  #     Process.kill(sig, File.read(old_pid).to_i)
-  #   rescue Errno::ENOENT, Errno::ESRCH
-  #   end
-  # end
-  #
-  # Throttle the master from forking too quickly by sleeping.  Due
-  # to the implementation of standard Unix signal handlers, this
-  # helps (but does not completely) prevent identical, repeated signals
-  # from being lost when the receiving process is busy.
-  # sleep 1
 end
 
-after_fork do |server, worker|
-  # per-process listener ports for debugging/admin/migrations
-  # addr = "127.0.0.1:#{9293 + worker.nr}"
-  # server.listen(addr, :tries => -1, :delay => 5, :tcp_nopush => true)
-
-  # the following is *required* for Rails
-  defined?(ActiveRecord::Base) and
-    ActiveRecord::Base.establish_connection
-
-  # You may also want to check and
-  # restart any other shared sockets/descriptors such as Memcached,
-  # and Redis.
+after_worker_fork do |server, worker|
+  # You may want to check and restart any shared sockets/descriptors
 end

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -30,11 +30,11 @@ module Pitchfork
       :timeout => 20,
       :logger => Logger.new($stderr),
       :worker_processes => 1,
-      :after_fork => lambda { |server, worker|
+      :after_worker_fork => lambda { |server, worker|
         server.logger.info("worker=#{worker.nr} gen=#{worker.generation} pid=#{$$} spawned")
       },
-      :after_promotion => lambda { |server, worker|
-        server.logger.info("gen=#{worker.generation} pid=#{$$} promoted")
+      :after_mold_fork => lambda { |server, worker|
+        server.logger.info("mold gen=#{worker.generation} pid=#{$$} spawned")
       },
       :after_worker_exit => lambda { |server, worker, status|
         m = if worker.nil?
@@ -119,12 +119,12 @@ module Pitchfork
       set[:logger] = obj
     end
 
-    def after_fork(*args, &block)
-      set_hook(:after_fork, block_given? ? block : args[0])
+    def after_worker_fork(*args, &block)
+      set_hook(:after_worker_fork, block_given? ? block : args[0])
     end
 
-    def after_promotion(*args, &block)
-      set_hook(:after_promotion, block_given? ? block : args[0])
+    def after_mold_fork(*args, &block)
+      set_hook(:after_mold_fork, block_given? ? block : args[0])
     end
 
     def after_worker_ready(*args, &block)

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -7,7 +7,7 @@ module Pitchfork
   # releases of pitchfork.  Knowledge of this class is generally not
   # not needed for most users of pitchfork.
   #
-  # Some users may want to access it in the after_promotion/after_fork hooks.
+  # Some users may want to access it in the after_worker_fork/after_mold_fork hooks.
   # See the Pitchfork::Configurator RDoc for examples.
   class Worker
     # :stopdoc:

--- a/test/integration/t0020-at_exit-handler.sh
+++ b/test/integration/t0020-at_exit-handler.sh
@@ -8,7 +8,7 @@ t_begin "setup and startup" && {
 	cat >> $pitchfork_config <<EOF
 at_exit { \$stdout.syswrite("#{Process.pid} BOTH\\n") }
 END { \$stdout.syswrite("#{Process.pid} END BOTH\\n") }
-after_fork do |_,_|
+after_worker_fork do |_,_|
   at_exit { \$stdout.syswrite("#{Process.pid} WORKER ONLY\\n") }
   END { \$stdout.syswrite("#{Process.pid} END WORKER ONLY\\n") }
 end

--- a/test/integration/t0116-client_body_buffer_size.sh
+++ b/test/integration/t0116-client_body_buffer_size.sh
@@ -7,7 +7,7 @@ t_begin "setup and start" && {
 	rtmpfiles pitchfork_config_tmp one_meg
 	dd if=/dev/zero bs=1M count=1 of=$one_meg
 	cat >> $pitchfork_config <<EOF
-after_fork do |server, worker|
+after_worker_fork do |server, worker|
   File.open("$fifo", "wb") { |fp| fp.syswrite "START" }
 end
 EOF

--- a/test/integration/test_boot.rb
+++ b/test/integration/test_boot.rb
@@ -70,14 +70,14 @@ class TestBoot < Pitchfork::IntegrationTest
     assert_clean_shutdown(pid)
   end
 
-  def test_boot_broken_after_promotion
+  def test_boot_broken_after_mold_fork
     addr, port = unused_port
 
     pid = spawn_server(app: APP, config: <<~RUBY)
       listen "#{addr}:#{port}"
       worker_processes 2
       refork_after [50, 100, 1000]
-      after_promotion do |_server, _mold|
+      after_mold_fork do |_server, _mold|
         raise "Oops"
       end
     RUBY

--- a/test/integration/test_reap_logging.rb
+++ b/test/integration/test_reap_logging.rb
@@ -1,14 +1,14 @@
 require 'integration_test_helper'
 
 class ReapLoggingTest < Pitchfork::IntegrationTest
-  AFTER_FORK_FILE = 'after_fork'
+  AFTER_FORK_FILE = 'after_worker_fork'
   # TODO: This test is slow.
   def test_reap_worker_logging_messages
     addr, port = unused_port
 
     pid = spawn_server(app: File.join(ROOT, "test/integration/pid.ru"), config: <<~CONFIG,)
       listen "#{addr}:#{port}"
-      after_fork { |s,w| File.open('#{AFTER_FORK_FILE}','w') { |f| f.write '.' } }
+      after_worker_fork { |s,w| File.open('#{AFTER_FORK_FILE}','w') { |f| f.write '.' } }
     CONFIG
 
     assert_new_worker_forked
@@ -45,6 +45,6 @@ class ReapLoggingTest < Pitchfork::IntegrationTest
     end
 
     File.truncate(AFTER_FORK_FILE, 0)
-    assert new_worker_forked, "A worker did not write to after_fork within #{timeout} seconds."
+    assert new_worker_forked, "A worker did not write to after_worker_fork within #{timeout} seconds."
   end
 end

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -36,14 +36,14 @@ class ReforkingTest < Pitchfork::IntegrationTest
       assert_clean_shutdown(pid)
     end
 
-    def test_reforking_broken_after_promotion_hook
+    def test_reforking_broken_after_mold_fork_hook
       addr, port = unused_port
 
       pid = spawn_server(app: File.join(ROOT, "test/integration/env.ru"), config: <<~CONFIG)
         listen "#{addr}:#{port}"
         worker_processes 2
         refork_after [5, 5]
-        after_promotion do |_server, mold|
+        after_mold_fork do |_server, mold|
           raise "Oops" if mold.generation > 0
         end
       CONFIG

--- a/test/slow/test_signals.rb
+++ b/test/slow/test_signals.rb
@@ -32,7 +32,7 @@ class SignalsTest < Pitchfork::Test
     File.unlink(@tmp.path)
     @server_opts = {
       :listeners => [ "127.0.0.1:#@port", @sock.path ],
-      :after_fork => lambda { |server,worker|
+      :after_worker_fork => lambda { |server, worker|
         trap(:HUP) { @tmp.syswrite('.') }
       },
     }

--- a/test/unit/test_configurator.rb
+++ b/test/unit/test_configurator.rb
@@ -160,18 +160,18 @@ class TestConfigurator < Pitchfork::Test
     end
   end
 
-  def test_after_fork_proc
+  def test_after_worker_fork_proc
     test_struct = TestStruct.new
     [ proc { |a,b| }, Proc.new { |a,b| }, lambda { |a,b| } ].each do |my_proc|
-      Pitchfork::Configurator.new(:after_fork => my_proc).commit!(test_struct)
-      assert_equal my_proc, test_struct.after_fork
+      Pitchfork::Configurator.new(:after_worker_fork => my_proc).commit!(test_struct)
+      assert_equal my_proc, test_struct.after_worker_fork
     end
   end
 
-  def test_after_fork_wrong_arity
+  def test_after_worker_fork_wrong_arity
     [ proc { |a| }, Proc.new { }, lambda { |a,b,c| } ].each do |my_proc|
       assert_raises(ArgumentError) do
-        Pitchfork::Configurator.new(:after_fork => my_proc)
+        Pitchfork::Configurator.new(:after_worker_fork => my_proc)
       end
     end
   end


### PR DESCRIPTION
Now that the mold is forked rather than promoted, it makes more sense.