### PR TITLE
Use a fiber rather than a thread to implement `clean_fork`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Use a Fiber rather than a Thread to implement `clean_fork`.
+
 # 0.3.0
 
 - Renamed `after_promotion` in `after_mold_fork`.


### PR DESCRIPTION
It has several advantages, first we only need to copy fiber locals, actual thread local variables are preserved.

Additionally any code using `Thread.current` as a hash key won't be impacted.

And finally, native gems using APIs such a `pthread_atfork(3)` won't be impacted either, as the native thread will remain the same in the child.