### PR TITLE
Use throw/catch to unwind the stack post fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Use a Fiber rather than a Thread to implement `clean_fork`.
+- Preserve the current thread when reforking.
 
 # 0.3.0
 

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -733,10 +733,15 @@ module Pitchfork
           mold.start_promotion(@control_socket[1])
           mold_loop(mold)
         end
-        true
-      ensure
+      rescue
+        # HACK: we need to call this on error or on no error, but not on throw
+        # hence why we don't use `ensure`
+        @promotion_lock.at_fork
+        raise
+      else
         @promotion_lock.at_fork # We let the spawned mold own the lock
       end
+      true
     end
 
     def mold_loop(mold)


### PR DESCRIPTION
Fix: https://github.com/Shopify/pitchfork/pull/49#issuecomment-1587264229

The fiber solution has the huge drawback on restricting the stack space to just 4kiB, which is way too small for sizeable applications.

Instead we can use a throw with a callable argument to unwind the stack and resume execution.