### PR TITLE
Allow to mark workers as fork unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Expose `Pitchfork::Info.fork_safe?` and `Pitchfork::Info.no_longer_fork_safe!`.
+
 # 0.6.0
 
 - Expose `Pitchfork::Info.workers_count` and `.live_workers_count` to be consumed by application health checks.

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -811,7 +811,7 @@ module Pitchfork
           # timeout so we can update .deadline and keep parent from SIGKILL-ing us
           worker.update_deadline(@timeout)
 
-          if @refork_condition && !worker.outdated?
+          if @refork_condition && Info.fork_safe? && !worker.outdated?
             if @refork_condition.met?(worker, logger)
               if spawn_mold(worker.generation)
                 logger.info("Refork condition met, promoting ourselves")

--- a/lib/pitchfork/info.rb
+++ b/lib/pitchfork/info.rb
@@ -5,9 +5,18 @@ require 'pitchfork/shared_memory'
 module Pitchfork
   module Info
     @workers_count = 0
+    @fork_safe = true
 
     class << self
       attr_accessor :workers_count
+
+      def fork_safe?
+        @fork_safe
+      end
+
+      def no_longer_fork_safe!
+        @fork_safe = false
+      end
 
       def live_workers_count
         now = Pitchfork.time_now(true)

--- a/test/integration/fork_unsafe.ru
+++ b/test/integration/fork_unsafe.ru
@@ -1,0 +1,6 @@
+use Rack::ContentLength
+use Rack::ContentType, "text/plain"
+run lambda { |env|
+  Pitchfork::Info.no_longer_fork_safe!
+  [ 200, {}, [ env.inspect << "\n" ] ]
+}


### PR DESCRIPTION
When some part of an application is hard or impossible to make fork-safe, but rarely called, it's possible to simply mark the worker as fork unsafe, and rely on its siblings to fork the next generation.

In the eventually where all the workers end up marked fork unsafe, no new generation will be spawned, unless of course one of the unsafe workers die and is replaced by a fresh one.

So this is only meant as a workaround for infrequently called things.