### PR TITLE
Handle not yet registered workers

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -629,8 +629,11 @@ module Pitchfork
       if workers_to_restart > 0
         outdated_workers = @children.workers.select { |w| !w.exiting? && w.generation < @children.mold.generation }
         outdated_workers.each do |worker|
-          logger.info("worker=#{worker.nr} pid=#{worker.pid} gen=#{worker.generation} restarting")
-          worker.soft_kill(:TERM)
+          if worker.soft_kill(:TERM)
+            logger.info("Sent SIGTERM to worker=#{worker.nr} pid=#{worker.pid} gen=#{worker.generation}")
+          else
+            logger.info("Failed to send SIGTERM to worker=#{worker.nr} pid=#{worker.pid} gen=#{worker.generation}")
+          end
         end
       end
     end

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -215,6 +215,7 @@ module Pitchfork
 
     def send_message_nonblock(message)
       success = false
+      return false unless @master
       begin
         case @master.sendmsg_nonblock(message, exception: false)
         when :wait_writable


### PR DESCRIPTION
Fix: https://github.com/Shopify/pitchfork/issues/57

I suspect it's a race condition caused by a workers being freshly respawned but not yet registered.

In such case we don't have a socket to write into, we should just wait.