### PR TITLE
Pass the last request env to after_request_complete

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -371,7 +371,7 @@ Called in the worker processes after a request has completed.
 Can be used for out of band work, or to exit unhealthy workers.
 
 ```ruby
-after_request_complete do |server, worker|
+after_request_complete do |server, worker, env|
   if something_wrong?
     exit
   end

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -158,7 +158,7 @@ module Pitchfork
     end
 
     def after_request_complete(*args, &block)
-      set_hook(:after_request_complete, block_given? ? block : args[0])
+      set_hook(:after_request_complete, block_given? ? block : args[0], 3)
     end
 
     def timeout(seconds, cleanup: 2)

--- a/test/integration/test_configuration.rb
+++ b/test/integration/test_configuration.rb
@@ -9,9 +9,9 @@ class ConfigurationTest < Pitchfork::IntegrationTest
       worker_processes 1
 
       request_count = 0
-      after_request_complete do |server, worker|
+      after_request_complete do |server, worker, env|
         request_count += 1
-        $stderr.puts "[after_request_complete] request_count=\#{request_count}"
+        $stderr.puts "[after_request_complete] request_count=\#{request_count} path=\#{env['PATH_INFO']}"
       end
 
       before_worker_exit do |server, worker|
@@ -20,7 +20,7 @@ class ConfigurationTest < Pitchfork::IntegrationTest
     CONFIG
 
     assert_healthy("http://#{addr}:#{port}")
-    assert_stderr("[after_request_complete] request_count=1")
+    assert_stderr("[after_request_complete] request_count=1 path=/")
     assert_healthy("http://#{addr}:#{port}")
 
     assert_clean_shutdown(pid)


### PR DESCRIPTION
This is useful for reporting if the hook is used to terminate the worker or something.

E.g. if you detect something went wrong and the worker must exit, you may want to report some informations about the request that caused it.