### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "Ruby",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+			// Path is relative to the devcontainer.json file.
+			"dockerfile": "../Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bundle install"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM mcr.microsoft.com/devcontainers/ruby:1-3.2-bookworm
 RUN apt-get update -y && apt-get install -y ragel socat netcat-traditional smem apache2-utils
 WORKDIR /app
 CMD [ "bash" ]


### PR DESCRIPTION
This project already have a Dockerfile to make it easier to develop since it depends on a lot of feature from linux. However, if users develop using VSCode it would be good to have a devcontainer config to make this Dockerfile just work.

This require changing the base image to the devcontainer images that include the vscode server and other developer tools.