### PR TITLE
Add an `after_monitor_ready` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add an `after_monitor_ready` callback, called in the monitor process at end of boot.
 - Implement `Pitchfork.prevent_fork` for use in background threads that synchronize native locks with the GVL released.
 
 # 0.7.0

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -253,12 +253,23 @@ The default Logger will log its output to STDERR.
 Because pitchfork several callbacks around the lifecycle of workers.
 It is often necessary to use these callbacks to close inherited connection after fork.
 
-Note that when reforking is available, the `pitchfork` master process won't load your application
-at all. As such for hooks executed in the master, you may need to explicitly load the parts of your
+Note that when reforking is available, the `pitchfork` monitor process won't load your application
+at all. As such for hooks executed in the monitor, you may need to explicitly load the parts of your
 application that are used in hooks.
 
 `pitchfork` also don't attempt to rescue hook errors. Raising from a worker hook will crash the worker,
-and raising from a master hook will bring the whole cluster down.
+and raising from a monitor hook will bring the whole cluster down.
+
+### `after_monitor_ready`
+
+Called by the monitor process after it's done booting the application and
+spawning the original workers.
+
+```ruby
+after_monitor_ready do |server|
+  server.logger.info("Monitor pid=#{Process.pid} ready")
+end
+```
 
 ### `after_mold_fork`
 
@@ -338,7 +349,7 @@ By default the cleanup timeout is 2 seconds.
 
 ### `after_worker_hard_timeout`
 
-Called in the master process when a worker hard timeout is elapsed:
+Called in the monitor process when a worker hard timeout is elapsed:
 
 ```ruby
 after_worker_timeout do |server, worker|
@@ -353,7 +364,7 @@ soft timeout from working.
 
 ### `after_worker_exit`
 
-Called in the master process after a worker exits.
+Called in the monitor process after a worker exits.
 
 ```ruby
 after_worker_exit do |server, worker, status|

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -60,6 +60,9 @@ module Pitchfork
       :after_worker_ready => lambda { |server, worker|
         server.logger.info("worker=#{worker.nr} gen=#{worker.generation} ready")
       },
+      :after_monitor_ready => lambda { |server|
+        server.logger.info("Monitor pid=#{Process.pid} ready")
+      },
       :after_worker_timeout => nil,
       :after_worker_hard_timeout => nil,
       :after_request_complete => nil,
@@ -139,6 +142,10 @@ module Pitchfork
 
     def after_worker_ready(*args, &block)
       set_hook(:after_worker_ready, block_given? ? block : args[0])
+    end
+
+    def after_monitor_ready(*args, &block)
+      set_hook(:after_monitor_ready, block_given? ? block : args[0], 1)
     end
 
     def after_worker_timeout(*args, &block)

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -80,7 +80,7 @@ module Pitchfork
                   :orig_app, :config, :ready_pipe,
                   :default_middleware, :early_hints
     attr_writer   :after_worker_exit, :before_worker_exit, :after_worker_ready, :after_request_complete,
-                  :refork_condition, :after_worker_timeout, :after_worker_hard_timeout
+                  :refork_condition, :after_worker_timeout, :after_worker_hard_timeout, :after_monitor_ready
 
     attr_reader :logger
     include Pitchfork::SocketHelper
@@ -211,6 +211,8 @@ module Pitchfork
         # once all initial workers are spawned.
         wait_for_pending_workers
       end
+
+      @after_monitor_ready&.call(self)
 
       self
     end


### PR DESCRIPTION
Can be used to start an instrumentation thread or similar.

FYI @DazWorrall 