### PR TITLE
Implement `spawn_timeout` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Implement `spawn_timeout` to protect against bugs causing workers to get stuck before they reach ready state.
+
 # 0.8.0
 
 - Add an `after_monitor_ready` callback, called in the monitor process at end of boot.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -238,6 +238,19 @@ exit or be SIGKILL-ed due to timeouts.
 See https://nginx.org/en/docs/http/ngx_http_upstream_module.html
 for more details on nginx upstream configuration.
 
+### `spawn_timeout`
+
+```ruby
+timeout 5
+```
+
+Sets the timeout for a newly spawned worker to be ready after being spawned.
+
+This timeout is a safeguard against various low-level fork safety bugs that could cause
+a process to dead-lock.
+
+The default of `10` seconds is quite generous and likely doesn't need to be adjusted.
+
 ### `logger`
 
 ```ruby

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -33,6 +33,7 @@ module Pitchfork
     DEFAULTS = {
       :soft_timeout => 20,
       :cleanup_timeout => 2,
+      :spawn_timeout => 10,
       :timeout => 22,
       :logger => default_logger,
       :worker_processes => 1,
@@ -172,6 +173,10 @@ module Pitchfork
       soft_timeout = set_int(:soft_timeout, seconds, 3)
       cleanup_timeout = set_int(:cleanup_timeout, cleanup, 2)
       set_int(:timeout, soft_timeout + cleanup_timeout, 5)
+    end
+
+    def spawn_timeout(seconds)
+      set_int(:spawn_timeout, seconds, 1)
     end
 
     def worker_processes(nr)


### PR DESCRIPTION
Some low level fork safety bugs can cause workers to lock up before they reach the process client loop.

See: https://github.com/Shopify/pitchfork/pull/67

While such bugs should be avoided, Pitchfork should still try to recover from it, and killing newly spawned workers that didn't reach ready state should prevent cascading failure.