### PR TITLE
Handle fork_sibling failing repeatedly

### DIFF
--- a/bin/dev-console
+++ b/bin/dev-console
@@ -4,7 +4,7 @@
 # this script gives a quick dev environment for macOS
 # and Windows contributors.
 runner="docker"
-if command -v podman >/dev/null 2>&1; then
+if ! command -v docker >/dev/null 2>&1; then
   runner="podman"
 fi
 

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -66,6 +66,11 @@ module Pitchfork
       @workers.key?(nr)
     end
 
+    def abandon(worker)
+      @workers.delete(worker.nr)
+      @pending_workers.delete(worker.nr)
+    end
+
     def reap(pid)
       if child = @children.delete(pid)
         @pending_workers.delete(child.nr)
@@ -73,6 +78,9 @@ module Pitchfork
         @molds.delete(child.pid)
         @workers.delete(child.nr)
         if @mold == child
+          @pending_workers.reject! do |nr, worker|
+            worker.generation == @mold.generation
+          end
           @mold = nil
         end
       end

--- a/test/integration/test_boot.rb
+++ b/test/integration/test_boot.rb
@@ -104,8 +104,8 @@ class TestBoot < Pitchfork::IntegrationTest
     assert_healthy("http://#{addr}:#{port}")
 
     assert_stderr("worker=0 gen=0 ready")
-    assert_stderr(/worker=1 pid=\d+ registered/)
-    assert_stderr(/worker=1 pid=\d+ timed out, killing/, timeout: 4)
+    assert_stderr(/worker=1 pid=\d+ gen=0 registered/)
+    assert_stderr(/worker=1 pid=\d+ gen=0 timed out, killing/, timeout: 4)
 
     assert_clean_shutdown(pid)
   end

--- a/test/unit/test_children.rb
+++ b/test/unit/test_children.rb
@@ -22,9 +22,11 @@ module Pitchfork
       worker = Worker.new(0)
       @children.register(worker)
       assert_predicate @children, :pending_workers?
+      assert @children.nr_alive?(0)
 
       @children.update(Message::WorkerSpawned.new(0, 42, 0, pipe))
       refute_predicate @children, :pending_workers?
+      assert @children.nr_alive?(0), @children.inspect
       assert_equal 42, worker.pid
       assert_equal [worker], @children.workers
     end


### PR DESCRIPTION
Ref: https://github.com/Shopify/pitchfork/issues/79

It can happen that the new mold was forked while at an unsafe point, causing the middle process to crash.

When we detect this happens, we should abandon this mold.

Currently abandoning the mold cause a graceful shutdown, in the future we could try creating a new mold to replace it.