### PR TITLE
Fixed access to clean_fork

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -1049,7 +1049,7 @@ module Pitchfork
           exit
         end
       else
-        clean_fork(&block)
+        Pitchfork.clean_fork(&block)
       end
     end
 


### PR DESCRIPTION
The change of #84 had caused an error when `clean_fork` could not be accessed, so this has been corrected.

```
 ERROR -- [Pitchfork]: undefined method `clean_fork' for #<Pitchfork::HttpServer:0x0000000107a44ce8 @exit_status=0, @
```