### PR TITLE
expose pitchfork worker in env

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -722,6 +722,7 @@ module Pitchfork
 
       proc_name status: "requests: #{worker.requests_count}, processing: #{env["PATH_INFO"]}"
 
+      env["pitchfork.worker"] = worker
       timeout_handler.rack_env = env
       env["pitchfork.timeout"] = timeout_handler
 


### PR DESCRIPTION
which is helpful for logging for example worker.nr in app error handling. we're in the process of tracking down a SSL session corruption bug in our HTTP library and we're trying to work out when it occurs if its happening across all workers or just one, it's impossible to tell at the moment because the hostname for all the errors is the same, being about to log `worker.nr` alongside that would answer the question