### PR TITLE
Handle errors in `rack.after_reply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Implement `rack.response_finished` (#97).
 - Don't break the `rack.after_reply` callback chain if one callback raises (#97).
 
 # 0.11.1

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -732,7 +732,7 @@ module Pitchfork
         end
       end
 
-      env["rack.after_reply"] = []
+      env["rack.response_finished"] = env["rack.after_reply"] = []
 
       status, headers, body = @app.call(env)
 
@@ -758,15 +758,19 @@ module Pitchfork
         client.close # flush and uncork socket immediately, no keepalive
       end
       env
-    rescue => e
-      handle_error(client, e)
+    rescue => application_error
+      handle_error(client, application_error)
       env
     ensure
       if env
-        env["rack.after_reply"].each do |callback|
-          callback.call
-        rescue => error
-          Pitchfork.log_error(@logger, "rack.after_reply error", error)
+        env["rack.response_finished"].each do |callback|
+          if callback.arity == 0
+            callback.call
+          else
+            callback.call(env, status, headers, application_error)
+          end
+        rescue => callback_error
+          Pitchfork.log_error(@logger, "rack.after_reply error", callback_error)
         end
       end
       timeout_handler.finished


### PR DESCRIPTION
Ref: https://github.com/Shopify/pitchfork/issues/97

Don't break the callback chain if one callback raised.