### PR TITLE
Disable IO tracking on Rubies older than 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Disable IO tracking on Rubies older than 3.2.3 to avoid running into https://bugs.ruby-lang.org/issues/19531.
+  This Ruby bug can lead to memory corruption that cause VM crashes when calling various IO methods.
 - Implement `rack.response_finished` (#97).
 - Don't break the `rack.after_reply` callback chain if one callback raises (#97).
 

--- a/test/unit/test_info.rb
+++ b/test/unit/test_info.rb
@@ -4,38 +4,40 @@ require 'test_helper'
 
 class TestInfo < Pitchfork::Test
   def test_close_all_ios_except_marked_ones
-    if RUBY_VERSION < '3.2' && ENV["CI"]
-      skip "Older rubies have very buggy Weak Maps."
+    if RUBY_VERSION < '3.2.3'
+      assert_raises NoMethodError do
+        Pitchfork::Info.close_all_ios!
+      end
+    else
+      r, w = IO.pipe
+
+      Pitchfork::Info.keep_io(w)
+
+      pid = Process.fork do
+        Pitchfork::Info.close_all_ios!
+
+        w.write(Marshal.dump([
+          $stdin.closed?,
+          $stdout.closed?,
+          $stderr.closed?,
+          r.closed?,
+          w.closed?
+        ]))
+        Process.exit!(0)
+      end
+
+      _, status = Process.wait2(pid)
+      assert_predicate status, :success?
+
+      info = Marshal.load(r)
+
+      assert_equal([
+        false, # $stdin
+        false, # $stdout
+        false, # $stderr
+        true, # r
+        false, # w
+      ], info)
     end
-
-    r, w = IO.pipe
-
-    Pitchfork::Info.keep_io(w)
-
-    pid = Process.fork do
-      Pitchfork::Info.close_all_ios!
-
-      w.write(Marshal.dump([
-        $stdin.closed?,
-        $stdout.closed?,
-        $stderr.closed?,
-        r.closed?,
-        w.closed?
-      ]))
-      Process.exit!(0)
-    end
-
-    _, status = Process.wait2(pid)
-    assert_predicate status, :success?
-
-    info = Marshal.load(r)
-
-    assert_equal([
-      false, # $stdin
-      false, # $stdout
-      false, # $stderr
-      true, # r
-      false, # w
-    ], info)
   end
 end


### PR DESCRIPTION
To avoid running into https://bugs.ruby-lang.org/issues/19531.

Ref: https://github.com/Shopify/pitchfork/issues/100

This Ruby bug can lead to memory corruption that cause VM crashes when calling various IO methods.