### PR TITLE
Ensure compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Install packages
         run: sudo apt-get install -y ragel socat netcat
 
-      - name: Tests
+      - name: Tests ${{ matrix.rubyopt }}
         run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rake-compiler
 
 BUNDLED WITH
-   2.3.22
+   2.3.27

--- a/benchmark/cow_benchmark.rb
+++ b/benchmark/cow_benchmark.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require "net/http"
 
 app_path = File.expand_path('../examples/constant_caches.ru', __dir__)

--- a/examples/constant_caches.ru
+++ b/examples/constant_caches.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../lib/pitchfork/mem_info"
 
 module App

--- a/examples/echo.ru
+++ b/examples/echo.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Example application that echoes read data back to the HTTP client.
 # This emulates the old echo protocol people used to run.
 #

--- a/examples/hello.ru
+++ b/examples/hello.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 run lambda { |env|
   /\A100-continue\z/i =~ env['HTTP_EXPECT'] and return [100, {}, []]
   body = "Hello World!\n"

--- a/examples/pitchfork.conf.minimal.rb
+++ b/examples/pitchfork.conf.minimal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Minimal sample configuration file for Pitchfork
 
 # listen 2007 # by default Pitchfork listens on port 8080

--- a/examples/pitchfork.conf.rb
+++ b/examples/pitchfork.conf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Sample verbose configuration file for Pitchfork
 
 # Use at least one worker per core if you're on a dedicated server,

--- a/exe/pitchfork
+++ b/exe/pitchfork
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # -*- encoding: binary -*-
 require 'pitchfork/launcher'
 require 'optparse'

--- a/ext/pitchfork_http/extconf.rb
+++ b/ext/pitchfork_http/extconf.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'mkmf'
 
 have_const("PR_SET_CHILD_SUBREAPER", "sys/prctl.h")

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'etc'
 require 'stringio'
 require 'raindrops'

--- a/lib/pitchfork/app/old_rails/static.rb
+++ b/lib/pitchfork/app/old_rails/static.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # :enddoc:
 # This code is based on the original Rails handler in Mongrel
 # Copyright (c) 2005 Zed A. Shaw

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 module Pitchfork
   # This class keep tracks of the state of all the master children.

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'logger'
 
 module Pitchfork

--- a/lib/pitchfork/const.rb
+++ b/lib/pitchfork/const.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 module Pitchfork
   module Const # :nodoc:

--- a/lib/pitchfork/flock.rb
+++ b/lib/pitchfork/flock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'tempfile'
 
 module Pitchfork

--- a/lib/pitchfork/http_parser.rb
+++ b/lib/pitchfork/http_parser.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # :enddoc:
 # no stable API here
 
@@ -19,10 +20,10 @@ module Pitchfork
       "SERVER_SOFTWARE" => "Pitchfork #{Pitchfork::Const::UNICORN_VERSION}"
     }
 
-    NULL_IO = StringIO.new("")
+    NULL_IO = StringIO.new.binmode
 
     # :stopdoc:
-    HTTP_RESPONSE_START = [ 'HTTP'.freeze, '/1.1 '.freeze ]
+    HTTP_RESPONSE_START = [ 'HTTP', '/1.1 ' ]
     EMPTY_ARRAY = [].freeze
     @@input_class = Pitchfork::TeeInput
     @@check_client_connection = false
@@ -104,7 +105,7 @@ module Pitchfork
     end
 
     def hijacked?
-      env.include?('rack.hijack_io'.freeze)
+      env.include?('rack.hijack_io')
     end
 
     if Raindrops.const_defined?(:TCP_Info)
@@ -199,11 +200,11 @@ module Pitchfork
         val.downcase!
       end
 
-      if vals.pop == 'chunked'.freeze
-        return true unless vals.include?('chunked'.freeze)
+      if vals.pop == 'chunked'
+        return true unless vals.include?('chunked')
         raise Pitchfork::HttpParserError, 'double chunked', []
       end
-      return false unless vals.include?('chunked'.freeze)
+      return false unless vals.include?('chunked')
       raise Pitchfork::HttpParserError, 'chunked not last', []
     end
   end

--- a/lib/pitchfork/http_response.rb
+++ b/lib/pitchfork/http_response.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # :enddoc:
 
 module Pitchfork
@@ -48,10 +49,10 @@ module Pitchfork
       if headers
         code = status.to_i
         msg = STATUS_CODES[code]
-        start = req.response_start_sent ? ''.freeze : 'HTTP/1.1 '.freeze
+        start = req.response_start_sent ? '' : 'HTTP/1.1 '
         buf = "#{start}#{msg ? %Q(#{code} #{msg}) : status}\r\n" \
               "Date: #{httpdate}\r\n" \
-              "Connection: close\r\n"
+              "Connection: close\r\n".b
         headers.each do |key, value|
           case key
           when %r{\A(?:Date|Connection)\z}i

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -1,4 +1,6 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
+
 require 'pitchfork/pitchfork_http'
 require 'pitchfork/flock'
 require 'pitchfork/soft_timeout'
@@ -91,7 +93,7 @@ module Pitchfork
     # in new projects
     LISTENERS = []
 
-    NOOP = '.'.freeze
+    NOOP = '.'
 
     # :startdoc:
     # This Hash is considered a stable interface and changing its contents
@@ -696,7 +698,7 @@ module Pitchfork
 
     def e103_response_write(client, headers)
       rss = @request.response_start_sent
-      buf = rss ? "103 Early Hints\r\n" : "HTTP/1.1 103 Early Hints\r\n"
+      buf = (rss ? "103 Early Hints\r\n" : "HTTP/1.1 103 Early Hints\r\n").b
       headers.each { |key, value| append_header(buf, key, value) }
       buf << (rss ? "\r\nHTTP/1.1 ".freeze : "\r\n".freeze)
       client.write(buf)
@@ -710,7 +712,7 @@ module Pitchfork
       client.write(@request.response_start_sent ?
                    "100 Continue\r\n\r\nHTTP/1.1 ".freeze :
                    "HTTP/1.1 100 Continue\r\n\r\n".freeze)
-      env.delete('HTTP_EXPECT'.freeze)
+      env.delete('HTTP_EXPECT')
     end
 
     # once a client is accepted, it is processed in its entirety here

--- a/lib/pitchfork/launcher.rb
+++ b/lib/pitchfork/launcher.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # :enddoc:
 $stdout.sync = $stderr.sync = true

--- a/lib/pitchfork/message.rb
+++ b/lib/pitchfork/message.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # :stopdoc:
 module Pitchfork

--- a/lib/pitchfork/select_waiter.rb
+++ b/lib/pitchfork/select_waiter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Pitchfork
   # fallback for non-Linux and Linux <4.5 systems w/o EPOLLEXCLUSIVE
   class SelectWaiter # :nodoc:

--- a/lib/pitchfork/socket_helper.rb
+++ b/lib/pitchfork/socket_helper.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # :enddoc:
 require 'socket'
 

--- a/lib/pitchfork/stream_input.rb
+++ b/lib/pitchfork/stream_input.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 module Pitchfork
   # When processing uploads, pitchfork may expose a StreamInput object under
@@ -17,7 +18,7 @@ module Pitchfork
       @socket = socket
       @parser = request
       @buf = request.buf
-      @rbuf = ''
+      @rbuf = +''
       @bytes_read = 0
       filter_body(@rbuf, @buf) unless @buf.empty?
     end
@@ -41,7 +42,7 @@ module Pitchfork
     # ios.read(length [, buffer]) will return immediately if there is
     # any data and only block when nothing is available (providing
     # IO#readpartial semantics).
-    def read(length = nil, rv = '')
+    def read(length = nil, rv = ''.b)
       if length
         if length <= @rbuf.size
           length < 0 and raise ArgumentError, "negative length #{length} given"
@@ -79,16 +80,16 @@ module Pitchfork
     # unlike IO#gets.
     def gets(sep = $/)
       if sep.nil?
-        read_all(rv = '')
+        read_all(rv = ''.b)
         return rv.empty? ? nil : rv
       end
       re = /\A(.*?#{Regexp.escape(sep)})/
 
       begin
-        @rbuf.sub!(re, '') and return $1
+        @rbuf.sub!(re, ''.b) and return $1
         return @rbuf.empty? ? nil : @rbuf.slice!(0, @rbuf.size) if eof?
         @socket.readpartial(@@io_chunk_size, @buf) or eof!
-        filter_body(once = '', @buf)
+        filter_body(once = ''.b, @buf)
         @rbuf << once
       end while true
     end

--- a/lib/pitchfork/tee_input.rb
+++ b/lib/pitchfork/tee_input.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 module Pitchfork
   # Acts like tee(1) on an input input to provide a input-like stream
@@ -42,7 +43,7 @@ module Pitchfork
       @len = request.content_length
       super
       @tmp = @len && @len <= @@client_body_buffer_size ?
-             StringIO.new("") : new_tmpio
+             StringIO.new.binmode : new_tmpio
     end
 
     # :call-seq:
@@ -121,7 +122,7 @@ module Pitchfork
 
     # consumes the stream of the socket
     def consume!
-      junk = ""
+      junk = "".b
       nil while read(@@io_chunk_size, junk)
     end
 

--- a/lib/pitchfork/tmpio.rb
+++ b/lib/pitchfork/tmpio.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # :stopdoc:
 require 'tmpdir'
 

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'pitchfork/shared_memory'
 
 module Pitchfork

--- a/test/integration/apps/chunked.ru
+++ b/test/integration/apps/chunked.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ChunkedBody
   def each(&block)
     ('A'..'Z').each do |char|

--- a/test/integration/apps/stream.ru
+++ b/test/integration/apps/stream.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ChunkedBody
   def each(&block)
     ('A'..'Z').each do |char|

--- a/test/integration/bin/content-md5-put
+++ b/test/integration/bin/content-md5-put
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # -*- encoding: binary -*-
 # simple chunked HTTP PUT request generator (and just that),
 # it reads stdin and writes to stdout so socat can write to a

--- a/test/integration/bin/sha1sum.rb
+++ b/test/integration/bin/sha1sum.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 # Reads from stdin and outputs the SHA1 hex digest of the input
 
 require 'digest/sha1'

--- a/test/integration/bin/unused_listen
+++ b/test/integration/bin/unused_listen
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # -*- encoding: binary -*-
 # this is to remain compatible with the unused_port function in the
 # Unicorn test/test_helper.rb file

--- a/test/integration/broken-app.ru
+++ b/test/integration/broken-app.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # we do not want Rack::Lint or anything to protect us
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"

--- a/test/integration/env.ru
+++ b/test/integration/env.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env| [ 200, {}, [ env.inspect << "\n" ] ] }

--- a/test/integration/fails-rack-lint.ru
+++ b/test/integration/fails-rack-lint.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This rack app returns a header with key named "status", which will cause
 # Rack::Lint to throw an exception if it is present.  This
 # is used to check whether Rack::Lint is in the stack or not.

--- a/test/integration/fork_unsafe.ru
+++ b/test/integration/fork_unsafe.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env|

--- a/test/integration/heartbeat-timeout.ru
+++ b/test/integration/heartbeat-timeout.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 headers = { 'content-type' => 'text/plain' }
 run lambda { |env|

--- a/test/integration/info.ru
+++ b/test/integration/info.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env|

--- a/test/integration/listener_names.ru
+++ b/test/integration/listener_names.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run(lambda { |_| [ 200, {}, [ Pitchfork.listener_names.inspect ] ] })

--- a/test/integration/pid.ru
+++ b/test/integration/pid.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env| [ 200, {}, [ "#$$\n" ] ] }

--- a/test/integration/rack-input-tests.ru
+++ b/test/integration/rack-input-tests.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # SHA1 checksum generator
 require 'digest/sha1'
 use Rack::ContentLength

--- a/test/integration/sleep.ru
+++ b/test/integration/sleep.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env|

--- a/test/integration/t0013.ru
+++ b/test/integration/t0013.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #\ -E none
 use Rack::ContentLength
 use Rack::ContentType, 'text/plain'

--- a/test/integration/t0014.ru
+++ b/test/integration/t0014.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #\ -E none
 use Rack::ContentLength
 use Rack::ContentType, 'text/plain'

--- a/test/integration/t0116.ru
+++ b/test/integration/t0116.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #\ -E none
 use Rack::ContentLength
 use Rack::ContentType, 'text/plain'

--- a/test/integration/t0301.ru
+++ b/test/integration/t0301.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #\-N --debug
 run(lambda do |env|
   case env['PATH_INFO']

--- a/test/integration/t2000.ru
+++ b/test/integration/t2000.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 use Rack::ContentLength
 use Rack::ContentType, "text/plain"
 run lambda { |env|

--- a/test/integration/test_boot.rb
+++ b/test/integration/test_boot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class TestBoot < Pitchfork::IntegrationTest

--- a/test/integration/test_broken_app.rb
+++ b/test/integration/test_broken_app.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class BrokenAppTest < Pitchfork::IntegrationTest

--- a/test/integration/test_configuration.rb
+++ b/test/integration/test_configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class ConfigurationTest < Pitchfork::IntegrationTest

--- a/test/integration/test_heartbeat_timeout.rb
+++ b/test/integration/test_heartbeat_timeout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class HearbeatTimeoutTest < Pitchfork::IntegrationTest

--- a/test/integration/test_http_basic.rb
+++ b/test/integration/test_http_basic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class HttpBasicTest < Pitchfork::IntegrationTest

--- a/test/integration/test_info.rb
+++ b/test/integration/test_info.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class InfoTest < Pitchfork::IntegrationTest

--- a/test/integration/test_parser_error.rb
+++ b/test/integration/test_parser_error.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'integration_test_helper'
 

--- a/test/integration/test_reap_logging.rb
+++ b/test/integration/test_reap_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class ReapLoggingTest < Pitchfork::IntegrationTest

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'integration_test_helper'
 
 class ReforkingTest < Pitchfork::IntegrationTest

--- a/test/integration/write-on-close.ru
+++ b/test/integration/write-on-close.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class WriteOnClose
   def each(&block)
     @callback = block

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 module Pitchfork
@@ -53,6 +54,10 @@ module Pitchfork
         FileUtils.rm_rf(@pwd)
       else
         $stderr.puts("Working directory left at: #{@pwd}")
+        if ENV["CI"]
+          $stderr.puts "-" * 40
+          $stderr.puts(File.read(File.join(@pwd, "stderr.log")))
+        end
       end
 
       super

--- a/test/slow/test_server.rb
+++ b/test/slow/test_server.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2005 Zed A. Shaw
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or
@@ -271,7 +272,7 @@ class WebServerTest < Pitchfork::Test
   def do_test(string, chunk, close_after=nil, shutdown_delay=0)
     # Do not use instance variables here, because it needs to be thread safe
     socket = tcp_socket("127.0.0.1", @port);
-    request = StringIO.new(string)
+    request = StringIO.new(+string)
     chunks_out = 0
 
     while data = request.read(chunk)

--- a/test/slow/test_signals.rb
+++ b/test/slow/test_signals.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2009 Eric Wong
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or
@@ -131,7 +132,7 @@ class SignalsTest < Pitchfork::Test
     wait_workers_ready("test_stderr.#{$$}.log", 1)
     sock = tcp_socket('127.0.0.1', @port)
     sock.syswrite("GET / HTTP/1.0\r\n\r\n")
-    buf = ''
+    buf = ''.b
     header_len = pid = nil
     buf = sock.sysread(16384, buf)
     pid = buf[/\r\nX-Pid: (\d+)\r\n/, 1].to_i

--- a/test/slow/test_upload.rb
+++ b/test/slow/test_upload.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2009 Eric Wong
 require 'test_helper'
@@ -102,13 +103,13 @@ class UploadTest < Pitchfork::Test
     start_server(@sha1_app)
     assert_equal 256, length
     sock = tcp_socket(@addr, @port)
-    hdr = "PUT / HTTP/1.0\r\nContent-Length: #{length}\r\n\r\n"
+    hdr = +"PUT / HTTP/1.0\r\nContent-Length: #{length}\r\n\r\n"
     @count.times do
       buf = @random.sysread(@bs)
       @sha1.update(buf)
       hdr << buf
       sock.syswrite(hdr)
-      hdr = ''
+      hdr = ''.b
       sleep 0.6
     end
     read = sock.read.split(/\r\n/)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2005 Zed A. Shaw
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or

--- a/test/unit/test_ccc.rb
+++ b/test/unit/test_ccc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class TestCccTCPI < Pitchfork::Test

--- a/test/unit/test_children.rb
+++ b/test/unit/test_children.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'test_helper'
 
 module Pitchfork

--- a/test/unit/test_configurator.rb
+++ b/test/unit/test_configurator.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'test_helper'
 
 class TestConfigurator < Pitchfork::Test

--- a/test/unit/test_flock.rb
+++ b/test/unit/test_flock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class TestFlock < Pitchfork::Test

--- a/test/unit/test_http_parser.rb
+++ b/test/unit/test_http_parser.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2005 Zed A. Shaw
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or
@@ -346,7 +347,7 @@ module Pitchfork
       ).each do |path|
         parser = HttpParser.new
         req = parser.env
-        sorta_safe = %(GET #{path} HTTP/1.1\r\n\r\n)
+        sorta_safe = +%(GET #{path} HTTP/1.1\r\n\r\n)
         assert_equal req, parser.headers(req, sorta_safe)
         assert_equal path, req['REQUEST_URI']
         assert_equal '', sorta_safe
@@ -364,14 +365,14 @@ module Pitchfork
       # make sure we can recover
       parser.clear
       req.clear
-      assert_equal req, parser.headers(req, "GET / HTTP/1.0\r\n\r\n")
+      assert_equal req, parser.headers(req, "GET / HTTP/1.0\r\n\r\n".b)
       assert ! parser.keepalive?
     end
 
     def test_piecemeal
       parser = HttpParser.new
       req = parser.env
-      http = "GET"
+      http = "GET".b
       assert_nil parser.headers(req, http)
       assert_nil parser.headers(req, http)
       assert_nil parser.headers(req, http << " / HTTP/1.0")
@@ -433,7 +434,7 @@ module Pitchfork
       "#{URI::REGEXP::PATTERN::UNRESERVED};:&=+$,".split(//).each do |char|
         parser = HttpParser.new
         req = parser.env
-        http = "GET http://#{char}@example.com/ HTTP/1.0\r\n\r\n"
+        http = +"GET http://#{char}@example.com/ HTTP/1.0\r\n\r\n"
         assert_equal req, parser.headers(req, http)
         assert_equal 'http', req['rack.url_scheme']
         assert_equal '/', req['REQUEST_URI']
@@ -526,7 +527,7 @@ module Pitchfork
       parser = HttpParser.new
       req = parser.env
       url = "http://[::1]/foo?q=bar"
-      http = "GET #{url} HTTP/1.1\r\n" \
+      http = +"GET #{url} HTTP/1.1\r\n" \
              "Host: bad.example.com\r\n\r\n"
       assert_equal req, parser.headers(req, http)
       assert_equal 'http', req['rack.url_scheme']
@@ -548,7 +549,7 @@ module Pitchfork
       parser = HttpParser.new
       req = parser.env
       url = "http://[::a]/"
-      http = "GET #{url} HTTP/1.1\r\n" \
+      http = +"GET #{url} HTTP/1.1\r\n" \
              "Host: bad.example.com\r\n\r\n"
       assert_equal req, parser.headers(req, http)
       assert_equal 'http', req['rack.url_scheme']
@@ -565,7 +566,7 @@ module Pitchfork
       parser = HttpParser.new
       req = parser.env
       url = "http://[::B]/"
-      http = "GET #{url} HTTP/1.1\r\n" \
+      http = +"GET #{url} HTTP/1.1\r\n" \
              "Host: bad.example.com\r\n\r\n"
       assert_equal req, parser.headers(req, http)
       assert_equal 'http', req['rack.url_scheme']
@@ -582,7 +583,7 @@ module Pitchfork
       parser = HttpParser.new
       req = parser.env
       url = "https://[::1]:/foo?q=bar"
-      http = "GET #{url} HTTP/1.1\r\n" \
+      http = +"GET #{url} HTTP/1.1\r\n" \
              "Host: bad.example.com\r\n\r\n"
       assert_equal req, parser.headers(req, http)
       assert_equal 'https', req['rack.url_scheme']
@@ -604,7 +605,7 @@ module Pitchfork
       parser = HttpParser.new
       req = parser.env
       url = "https://[::1]:666/foo?q=bar"
-      http = "GET #{url} HTTP/1.1\r\n" \
+      http = +"GET #{url} HTTP/1.1\r\n" \
              "Host: bad.example.com\r\n\r\n"
       assert_equal req, parser.headers(req, http)
       assert_equal 'https', req['rack.url_scheme']
@@ -704,7 +705,7 @@ module Pitchfork
       %w(GETT HEADR XGET XHEAD).each { |m|
         parser = HttpParser.new
         req = parser.env
-        s = "#{m} /forums/1/topics/2375?page=1#posts-17408 HTTP/1.1\r\n\r\n"
+        s = +"#{m} /forums/1/topics/2375?page=1#posts-17408 HTTP/1.1\r\n\r\n".b
         ok = parser.headers(req, s)
         assert ok
         assert_equal '/forums/1/topics/2375?page=1', req['REQUEST_URI']
@@ -769,7 +770,7 @@ module Pitchfork
       end
 
       # then large headers are rejected too
-      get = "GET /#{rand_data(10,120)} HTTP/1.1\r\n"
+      get = +"GET /#{rand_data(10,120)} HTTP/1.1\r\n"
       get << "X-Test: test\r\n" * (80 * 1024)
       parser.buf << get
       assert_raises(Pitchfork::HttpParserError,Pitchfork::RequestURITooLongError) do

--- a/test/unit/test_http_parser_ng.rb
+++ b/test/unit/test_http_parser_ng.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'test_helper'
 
@@ -100,7 +101,7 @@ module Pitchfork
 
     def test_identity_byte_headers
       req = @parser.env
-      str = "PUT / HTTP/1.1\r\n"
+      str = "PUT / HTTP/1.1\r\n".b
       str << "Content-Length: 123\r\n"
       str << "\r"
       hdr = @parser.buf
@@ -115,7 +116,7 @@ module Pitchfork
       assert ! @parser.keepalive?
       assert @parser.headers?
       assert_equal 123, @parser.content_length
-      dst = ""
+      dst = "".b
       buf = '.' * 123
       @parser.filter_body(dst, buf)
       assert_equal '.' * 123, dst
@@ -136,7 +137,7 @@ module Pitchfork
       assert_equal 0, str.size
       assert ! @parser.keepalive?
       assert @parser.headers?
-      dst = ""
+      dst = "".b
       buf = '.' * 123
       @parser.filter_body(dst, buf)
       assert_equal '.' * 123, dst
@@ -153,7 +154,7 @@ module Pitchfork
       assert_equal 0, str.size
       assert ! @parser.keepalive?
       assert @parser.headers?
-      dst = ""
+      dst = "".b
       buf = '.' * 123
       @parser.filter_body(dst, buf)
       assert_equal '.' * 123, dst
@@ -171,7 +172,7 @@ module Pitchfork
       assert_equal '123', req['CONTENT_LENGTH']
       assert_equal 123, str.size
       assert_equal body, str
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal 0, str.size
       assert_equal tmp, body
@@ -185,7 +186,7 @@ module Pitchfork
       assert_equal Hash, @parser.parse.class
       assert_equal 1, str.size
       assert_equal 'a', str
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal "", str
       assert_equal "a", tmp
@@ -204,7 +205,7 @@ module Pitchfork
       assert_equal Hash, @parser.parse.class
       assert_equal 2, str.size
       assert_equal 'aG', str
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal "G", str
       assert_equal "G", @parser.filter_body(tmp, str)
@@ -219,13 +220,13 @@ module Pitchfork
       str << "PUT / HTTP/1.1\r\ntransfer-Encoding: chunked\r\n\r\n"
       assert_equal req, @parser.parse, "msg=#{str}"
       assert_equal 0, str.size
-      tmp = ""
+      tmp = "".b
       assert_nil @parser.filter_body(tmp, str << "6")
       assert_equal 0, tmp.size
       assert_nil @parser.filter_body(tmp, str << "\r\n")
       assert_equal 0, str.size
       assert_equal 0, tmp.size
-      tmp = ""
+      tmp = "".b
       assert_nil @parser.filter_body(tmp, str << "..")
       assert_equal "..", tmp
       assert_nil @parser.filter_body(tmp, str << "abcd\r\n0\r\n")
@@ -245,7 +246,7 @@ module Pitchfork
       str << "PUT / HTTP/1.1\r\ntransfer-Encoding: chunked\r\n\r\n"
       assert_equal req, @parser.parse, "msg=#{str}"
       assert_equal 0, str.size
-      tmp = ""
+      tmp = "".b
       assert_equal str, @parser.filter_body(tmp, str << "0\r\n\r\n")
       assert_equal "", tmp
     end
@@ -256,13 +257,13 @@ module Pitchfork
       req = @parser.env
       assert_equal req, @parser.parse
       assert_equal 0, str.size
-      tmp = ""
+      tmp = "".b
       assert_nil @parser.filter_body(tmp, str << "6")
       assert_equal 0, tmp.size
       assert_nil @parser.filter_body(tmp, str << "\r\n")
       assert_equal "", str
       assert_equal 0, tmp.size
-      tmp = ""
+      tmp = "".b
       assert_nil @parser.filter_body(tmp, str << "..")
       assert_equal 2, tmp.size
       assert_equal "..", tmp
@@ -289,7 +290,7 @@ module Pitchfork
              "4000\r\nabcd"
       req = @parser.env
       assert_equal req, @parser.parse
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal '', str
       str << ' ' * 16300
@@ -315,7 +316,7 @@ module Pitchfork
       str << "PUT / HTTP/1.1\r\ntransfer-Encoding: chunked\r\n\r\n" \
              "1\r\na\r\n2\r\n..\r\n0\r\n"
       assert_equal req, @parser.parse
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal 'a..', tmp
       rv = @parser.filter_body(tmp, str)
@@ -331,8 +332,8 @@ module Pitchfork
       req = @parser.env
       assert_equal req, @parser.parse
       assert_equal "", buf
-      tmp = ''
-      body = ''
+      tmp = +''
+      body = +''
       str = chunked[0..-2]
       str.each_byte { |byte|
         assert_nil @parser.filter_body(tmp, buf << byte.chr)
@@ -354,7 +355,7 @@ module Pitchfork
       assert_equal req, @parser.parse
       assert_equal 'Content-MD5', req['HTTP_TRAILER']
       assert_nil req['HTTP_CONTENT_MD5']
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal 'a..', tmp
       md5_b64 = [ Digest::MD5.digest(tmp) ].pack('m').strip.freeze
@@ -384,7 +385,7 @@ module Pitchfork
       assert_equal req, @parser.parse
       assert_equal 'Content-MD5', req['HTTP_TRAILER']
       assert_nil req['HTTP_CONTENT_MD5']
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal 'a..', tmp
       md5_b64 = [ Digest::MD5.digest(tmp) ].pack('m').strip.freeze
@@ -413,7 +414,7 @@ module Pitchfork
       req = @parser.env
       assert_equal req, @parser.parse
       assert_nil @parser.content_length
-      @parser.filter_body('', str)
+      @parser.filter_body(''.b, str)
       assert ! @parser.keepalive?
     end
 
@@ -435,7 +436,7 @@ module Pitchfork
              "#{n.to_s(16)}\r\na\r\n2\r\n..\r\n0\r\n"
       assert_equal req, @parser.parse
       assert_nil @parser.content_length
-      assert_raises(HttpParserError) { @parser.filter_body('', str) }
+      assert_raises(HttpParserError) { @parser.filter_body(''.b, str) }
     end
 
     def test_overflow_content_length
@@ -451,7 +452,7 @@ module Pitchfork
       req = @parser.env
       assert_equal req, @parser.parse
       assert_nil @parser.content_length
-      assert_raises(HttpParserError) { @parser.filter_body("", @parser.buf) }
+      assert_raises(HttpParserError) { @parser.filter_body("".b, @parser.buf) }
     end
 
     def test_bad_content_length
@@ -468,7 +469,7 @@ module Pitchfork
              "1\r\na\r\n2\r\n..\r\n0\r\n"
       assert_equal req, @parser.parse
       assert_equal 'Transfer-Encoding', req['HTTP_TRAILER']
-      tmp = ''
+      tmp = +''
       assert_nil @parser.filter_body(tmp, str)
       assert_equal 'a..', tmp
       assert_equal '', str
@@ -589,7 +590,7 @@ module Pitchfork
     def test_chunked_overrides_content_length
       order = [ 'Transfer-Encoding: chunked', 'Content-Length: 666' ]
       %w(a b).each do |x|
-        str = "PUT /#{x} HTTP/1.1\r\n" \
+        str = +"PUT /#{x} HTTP/1.1\r\n" \
               "#{order.join("\r\n")}" \
               "\r\n\r\na\r\nhelloworld\r\n0\r\n\r\n"
         order.reverse!
@@ -598,7 +599,7 @@ module Pitchfork
         assert_equal 'chunked', env['HTTP_TRANSFER_ENCODING']
         assert_equal '666', env['CONTENT_LENGTH'],
           'Content-Length logged so the app can log a possible client bug/attack'
-        @parser.filter_body(dst = '', str)
+        @parser.filter_body(dst = ''.b, str)
         assert_equal 'helloworld', dst
         @parser.parse # handle the non-existent trailer
         assert @parser.next?
@@ -609,7 +610,7 @@ module Pitchfork
       str = "PUT /x HTTP/1.1\r\n" \
             "Transfer-Encoding: gzip\r\n" \
             "Transfer-Encoding: chunked\r\n" \
-            "\r\n"
+            "\r\n".b
       env = @parser.headers({}, str)
       assert_equal 'gzip,chunked', env['HTTP_TRANSFER_ENCODING']
       assert_nil @parser.content_length
@@ -617,7 +618,7 @@ module Pitchfork
       @parser.clear
       str = "PUT /x HTTP/1.1\r\n" \
             "Transfer-Encoding: gzip, chunked\r\n" \
-            "\r\n"
+            "\r\n".b
       env = @parser.headers({}, str)
       assert_equal 'gzip, chunked', env['HTTP_TRANSFER_ENCODING']
       assert_nil @parser.content_length
@@ -677,7 +678,7 @@ module Pitchfork
     end
 
     def test_pipelined_requests
-      host = "example.com"
+      host = "example.com".b
       expect = {
         "HTTP_HOST" => host,
         "SERVER_NAME" => host,

--- a/test/unit/test_refork_condition.rb
+++ b/test/unit/test_refork_condition.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 module Pitchfork

--- a/test/unit/test_request.rb
+++ b/test/unit/test_request.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2009 Eric Wong
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or

--- a/test/unit/test_response.rb
+++ b/test/unit/test_response.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 # Copyright (c) 2005 Zed A. Shaw
 # You can redistribute it and/or modify it under the same terms as Ruby 1.8 or

--- a/test/unit/test_socket_helper.rb
+++ b/test/unit/test_socket_helper.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/unit/test_soft_timeout.rb
+++ b/test/unit/test_soft_timeout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 module Pitchfork

--- a/test/unit/test_stream_input.rb
+++ b/test/unit/test_stream_input.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'test_helper'
 
@@ -97,7 +98,7 @@ class TestStreamInput < Pitchfork::Test
     @wr.close
     line = si.gets
     assert_equal(4096 * 4 * 3 + 5 + $/.size, line.size)
-    assert_equal("hello" << ("ffff" * 4096 * 3) << "#$/", line)
+    assert_equal("hello".b << ("ffff" * 4096 * 3) << "#$/", line)
     line = si.gets
     assert_equal "foo#$/", line
     assert_nil si.gets
@@ -108,7 +109,7 @@ class TestStreamInput < Pitchfork::Test
   def test_read_with_buffer
     r = init_request('hello')
     si = Pitchfork::StreamInput.new(@rd, r)
-    buf = ''
+    buf = ''.b
     rv = si.read(4, buf)
     assert_equal 'hell', rv
     assert_equal 'hell', buf
@@ -120,12 +121,12 @@ class TestStreamInput < Pitchfork::Test
   def test_read_with_buffer_clobbers
     r = init_request('hello')
     si = Pitchfork::StreamInput.new(@rd, r)
-    buf = 'foo'
+    buf = 'foo'.b
     assert_equal 'hello', si.read(nil, buf)
     assert_equal 'hello', buf
     assert_equal '', si.read(nil, buf)
     assert_equal '', buf
-    buf = 'asdf'
+    buf = 'asdf'.b
     assert_nil si.read(5, buf)
     assert_equal '', buf
   end
@@ -134,14 +135,14 @@ class TestStreamInput < Pitchfork::Test
     r = init_request('hello')
     si = Pitchfork::StreamInput.new(@rd, r)
     assert_equal '', si.read(0)
-    buf = 'asdf'
+    buf = 'asdf'.b
     rv = si.read(0, buf)
     assert_equal rv.object_id, buf.object_id
     assert_equal '', buf
     assert_equal 'hello', si.read
     assert_nil si.read(5)
     assert_equal '', si.read(0)
-    buf = 'hello'
+    buf = 'hello'.b
     rv = si.read(0, buf)
     assert_equal rv.object_id, buf.object_id
     assert_equal '', rv
@@ -158,7 +159,7 @@ class TestStreamInput < Pitchfork::Test
   def test_gets_read_mix_chunked
     r = @parser = Pitchfork::HttpParser.new
     body = "6\r\nhello"
-    @buf = "POST / HTTP/1.1\r\n" \
+    @buf = +"POST / HTTP/1.1\r\n" \
            "Host: localhost\r\n" \
            "Transfer-Encoding: chunked\r\n" \
            "\r\n#{body}"
@@ -187,7 +188,7 @@ class TestStreamInput < Pitchfork::Test
   def init_request(body, size = nil)
     @parser = Pitchfork::HttpParser.new
     body = body.to_s.freeze
-    @buf = "POST / HTTP/1.1\r\n" \
+    @buf = +"POST / HTTP/1.1\r\n" \
            "Host: localhost\r\n" \
            "Content-Length: #{size || body.size}\r\n" \
            "\r\n#{body}"

--- a/test/unit/test_tee_input.rb
+++ b/test/unit/test_tee_input.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'test_helper'
 
@@ -44,7 +45,7 @@ class TestTeeInput < Pitchfork::Test
     @wr.close
     line = ti.gets
     assert_equal(4096 * 4 * 3 + 5 + $/.size, line.size)
-    assert_equal("hello" << ("ffff" * 4096 * 3) << "#$/", line)
+    assert_equal("hello".b << ("ffff" * 4096 * 3) << "#$/", line)
     line = ti.gets
     assert_equal "foo#$/", line
     assert_nil ti.gets
@@ -88,7 +89,7 @@ class TestTeeInput < Pitchfork::Test
   def test_read_with_buffer
     r = init_request('hello')
     ti = TeeInput.new(@rd, r)
-    buf = ''
+    buf = ''.b
     rv = ti.read(4, buf)
     assert_equal 'hell', rv
     assert_equal 'hell', buf

--- a/test/unit/test_util.rb
+++ b/test/unit/test_util.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/unit/test_waiter.rb
+++ b/test/unit/test_waiter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'pitchfork/select_waiter'
 

--- a/test/unit/test_worker.rb
+++ b/test/unit/test_worker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class TestWorker < Pitchfork::Test


### PR DESCRIPTION
Make sure we'll be compatible with future versions of Ruby, and warning free starting in 3.4.