### PR TITLE
Extend child deadline after sending a hard timeout

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -514,6 +514,7 @@ module Pitchfork
           next
         else # worker is out of time
           next_sleep = 0
+          child.deadline = now + 1
           hard_timeout(child)
         end
       end


### PR DESCRIPTION
Ensure we won't hammer the process with similar signals.

Normally it doesn't happen as we sleep for 1 second, but monitor loop may be woken-up for other reasons which can lead to thousands of KILL signals being sent to to the same child.

One every 1 second should be plenty.