### PR TITLE
Include X-Request-Id header is worker proctitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `X-Request-Id` header in the workers proctitle if present.
+
 # 0.13.0
 
 - Fix compatibility with `--enable-frozen-string-literal` in preparation for Ruby 3.4.

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -723,7 +723,11 @@ module Pitchfork
       @request = Pitchfork::HttpParser.new
       env = @request.read(client)
 
-      proc_name status: "requests: #{worker.requests_count}, processing: #{env["PATH_INFO"]}"
+      status = "requests: #{worker.requests_count}, processing: #{env["PATH_INFO"]}"
+      if request_id = env["HTTP_X_REQUEST_ID"]
+        status += ", request_id: #{request_id}"
+      end
+      proc_name status: status
 
       env["pitchfork.worker"] = worker
       timeout_handler.rack_env = env


### PR DESCRIPTION
Useful to map a process with application logs.

FYI @tenderworks 