### PR TITLE
Promote `Process.warmup` for `after_mold_fork` with supported Rubies

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -299,8 +299,13 @@ end
 ```ruby
 after_mold_fork do |server, mold|
   Database.disconnect!
+
+  # Ruby < 3.3
   3.times { GC.start } # promote surviving objects to oldgen
   GC.compact
+
+  # Ruby >= 3.3
+  Process.warmup
 end
 ```
 


### PR DESCRIPTION
I've read https://github.com/Shopify/pitchfork/issues/87, compaction in particular was called out however the current example already does this as well so I believe this is fine without elaborating on that.