### PR TITLE
Add a job for frozen-string-literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,17 @@ on: [push, pull_request]
 
 jobs:
   ruby:
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} ${{ matrix.rubyopt }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         ruby: ["ruby-head", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+        rubyopt: [""]
+        include:
+          - ruby: "3.3"
+            rubyopt: "--enable-frozen-string-literal"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -26,4 +30,4 @@ jobs:
         run: sudo apt-get install -y ragel socat netcat
 
       - name: Tests ${{ matrix.rubyopt }}
-        run: bundle exec rake
+        run: RUBYOPT="${{ matrix.rubyopt }}" bundle exec rake


### PR DESCRIPTION
Followup to #102

Not super relevant since there are barely any dependencies and all/most files have the literal magic comment. The value is mostly to check against `raindrops` I think.

Since the workflow already contains a reference to `rubyopt` from that PR I'm not sure if this was intentionally left out or just forgotten.

