### PR TITLE
Remove stale mem_info function

### DIFF
--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -17,11 +17,6 @@ module Pitchfork
       @pending_molds = {} # Worker promoted to mold, not yet acknowledged
     end
 
-    def refresh
-      @workers.each_value(&:refresh)
-      @molds.each_value(&:refresh)
-    end
-
     def register(child)
       # Children always start as workers, never molds, so we know they have a `#nr`.
       @pending_workers[child.nr] = @workers[child.nr] = child
@@ -153,14 +148,6 @@ module Pitchfork
 
     def workers_count
       @workers.size
-    end
-
-    def total_pss
-      total_pss = MemInfo.new(Process.pid).pss
-      @children.each do |_, worker|
-        total_pss += worker.meminfo.pss if worker.meminfo
-      end
-      total_pss
     end
   end
 end

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -32,14 +32,6 @@ module Pitchfork
       end
     end
 
-    def meminfo
-      @meminfo ||= MemInfo.new(pid) if pid
-    end
-
-    def refresh
-      meminfo&.update
-    end
-
     def exiting?
       @exiting
     end


### PR DESCRIPTION
This used to be at least occasionally updated in https://github.com/Shopify/pitchfork/commit/aebdc2ec682df37705db6320f1f4a8d5f7f5daf6, in https://github.com/Shopify/pitchfork/commit/7239fba1036e88d0e7dedddbe1cfafc1e2030cad it got removed

The user is required to call refresh themselves in order to not get stale results after first access.

Removing `MemInfo` may be a overkill? You probably use that at Shopify, I distinctly remember a graph about cow efficiency somewhere. Generally I'm unsure about the level of backwards compatibility you want to guarantee at this time.