### PR TITLE
Fix off-by-one for `requests_count` during `after_request_complete`

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -849,8 +849,8 @@ module Pitchfork
                 worker.update(client)
               else
                 request_env = process_client(client, worker, prepare_timeout(worker))
-                @after_request_complete&.call(self, worker, request_env)
                 worker.increment_requests_count
+                @after_request_complete&.call(self, worker, request_env)
               end
               worker.update_deadline(@timeout)
             end

--- a/test/integration/test_configuration.rb
+++ b/test/integration/test_configuration.rb
@@ -9,10 +9,8 @@ class ConfigurationTest < Pitchfork::IntegrationTest
       listen "#{addr}:#{port}"
       worker_processes 1
 
-      request_count = 0
       after_request_complete do |server, worker, env|
-        request_count += 1
-        $stderr.puts "[after_request_complete] request_count=\#{request_count} path=\#{env['PATH_INFO']}"
+        $stderr.puts "[after_request_complete] worker_requests_count=\#{worker.requests_count} path=\#{env['PATH_INFO']}"
       end
 
       before_worker_exit do |server, worker|
@@ -21,7 +19,7 @@ class ConfigurationTest < Pitchfork::IntegrationTest
     CONFIG
 
     assert_healthy("http://#{addr}:#{port}")
-    assert_stderr("[after_request_complete] request_count=1 path=/")
+    assert_stderr("[after_request_complete] worker_requests_count=1 path=/")
     assert_healthy("http://#{addr}:#{port}")
 
     assert_clean_shutdown(pid)


### PR DESCRIPTION
The increment only happens after which made it lag behind