### PR TITLE
Enable `Style/RedundantFreeze`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  DisabledByDefault: true
+
+Style/RedundantFreeze:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem 'minitest'
 gem 'rake'
 gem 'rake-compiler'
+gem 'rubocop', '~> 1.63.0'
 
 group :benchmark do
   gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,41 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
     minitest (5.22.2)
     nio4r (2.7.0)
+    parallel (1.24.0)
+    parser (3.3.1.0)
+      ast (~> 2.4.1)
+      racc
     puma (6.4.2)
       nio4r (~> 2.0)
+    racc (1.7.3)
     rack (3.0.10)
+    rainbow (3.1.1)
     raindrops (0.20.1)
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake
+    regexp_parser (2.9.1)
+    rexml (3.2.6)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   aarch64-linux
@@ -29,6 +55,7 @@ DEPENDENCIES
   puma
   rake
   rake-compiler
+  rubocop (~> 1.63.0)
 
 BUNDLED WITH
    2.3.27

--- a/lib/pitchfork/http_parser.rb
+++ b/lib/pitchfork/http_parser.rb
@@ -114,7 +114,7 @@ module Pitchfork
       def check_client_connection(socket) # :nodoc:
         if TCPSocket === socket
           # Raindrops::TCP_Info#get!, #state (reads struct tcp_info#tcpi_state)
-          raise Errno::EPIPE, "client closed connection".freeze,
+          raise Errno::EPIPE, "client closed connection",
                 EMPTY_ARRAY if closed_state?(TCPI.get!(socket).state)
         else
           write_http_header(socket)
@@ -160,7 +160,7 @@ module Pitchfork
         if TCPSocket === socket && @@tcpi_inspect_ok
           opt = socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO).inspect
           if opt =~ /\bstate=(\S+)/
-            raise Errno::EPIPE, "client closed connection".freeze,
+            raise Errno::EPIPE, "client closed connection",
                   EMPTY_ARRAY if closed_state_str?($1)
           else
             @@tcpi_inspect_ok = false

--- a/lib/pitchfork/http_response.rb
+++ b/lib/pitchfork/http_response.rb
@@ -65,7 +65,7 @@ module Pitchfork
             append_header(buf, key, value)
           end
         end
-        socket.write(buf << "\r\n".freeze)
+        socket.write(buf << "\r\n")
       end
 
       if hijack

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -675,18 +675,14 @@ module Pitchfork
       rss = @request.response_start_sent
       buf = (rss ? "103 Early Hints\r\n" : "HTTP/1.1 103 Early Hints\r\n").b
       headers.each { |key, value| append_header(buf, key, value) }
-      buf << (rss ? "\r\nHTTP/1.1 ".freeze : "\r\n".freeze)
+      buf << (rss ? "\r\nHTTP/1.1 " : "\r\n")
       client.write(buf)
     end
 
     def e100_response_write(client, env)
-      # We use String#freeze to avoid allocations under Ruby 2.1+
-      # Not many users hit this code path, so it's better to reduce the
-      # constant table sizes even for Ruby 2.0 users who'll hit extra
-      # allocations here.
       client.write(@request.response_start_sent ?
-                   "100 Continue\r\n\r\nHTTP/1.1 ".freeze :
-                   "HTTP/1.1 100 Continue\r\n\r\n".freeze)
+                   "100 Continue\r\n\r\nHTTP/1.1 " :
+                   "HTTP/1.1 100 Continue\r\n\r\n")
       env.delete('HTTP_EXPECT')
     end
 

--- a/lib/pitchfork/socket_helper.rb
+++ b/lib/pitchfork/socket_helper.rb
@@ -72,7 +72,7 @@ module Pitchfork
         rescue => e
           logger.error("#{sock_name(sock)} " \
                        "failed to set accept_filter=#{name} (#{e.inspect})")
-          logger.error("perhaps accf_http(9) needs to be loaded".freeze)
+          logger.error("perhaps accf_http(9) needs to be loaded")
         end if arg != got
       end
     end

--- a/test/unit/test_http_parser_ng.rb
+++ b/test/unit/test_http_parser_ng.rb
@@ -67,7 +67,7 @@ module Pitchfork
     end
 
     def test_keepalive_requests_with_next?
-      req = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".freeze
+      req = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
       expect = {
         "SERVER_NAME" => "example.com",
         "HTTP_HOST" => "example.com",
@@ -362,7 +362,7 @@ module Pitchfork
       rv = @parser.filter_body(tmp, str)
       assert_equal rv.object_id, str.object_id
       assert_equal '', str
-      md5_hdr = "Content-MD5: #{md5_b64}\r\n".freeze
+      md5_hdr = "Content-MD5: #{md5_b64}\r\n"
       str << md5_hdr
       assert_nil @parser.trailers(req, str)
       assert_equal md5_b64, req['HTTP_CONTENT_MD5']
@@ -393,7 +393,7 @@ module Pitchfork
       assert_equal rv.object_id, str.object_id
       assert_equal '', str
       assert_nil @parser.trailers(req, str)
-      md5_hdr = "Content-MD5: #{md5_b64}\r\n".freeze
+      md5_hdr = "Content-MD5: #{md5_b64}\r\n"
       md5_hdr.each_byte { |byte|
         str << byte.chr
         assert_nil @parser.trailers(req, str)

--- a/test/unit/test_socket_helper.rb
+++ b/test/unit/test_socket_helper.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 class TestSocketHelper < Pitchfork::Test
   include Pitchfork::SocketHelper
   attr_reader :logger
-  GET_SLASH = "GET / HTTP/1.0\r\n\r\n".freeze
+  GET_SLASH = "GET / HTTP/1.0\r\n\r\n"
 
   def setup
     @log_tmp = Tempfile.new 'logger'


### PR DESCRIPTION
Testing the waters, intersted to know if you're open to this. This only enabled a single cop, and removes an outdated comment since all files now have frozen strings by default.

I guess the thing that would make most sense is using `rubocop-shopify`? Fix things up and add the commit into `.git-blame-ignore-revs`. I can set up CI and all that, otherwise feel free to close if you're not interested.