### PR TITLE
Remove redundant `.freeze` calls

### DIFF
--- a/lib/pitchfork/http_parser.rb
+++ b/lib/pitchfork/http_parser.rb
@@ -114,7 +114,7 @@ module Pitchfork
       def check_client_connection(socket) # :nodoc:
         if TCPSocket === socket
           # Raindrops::TCP_Info#get!, #state (reads struct tcp_info#tcpi_state)
-          raise Errno::EPIPE, "client closed connection".freeze,
+          raise Errno::EPIPE, "client closed connection",
                 EMPTY_ARRAY if closed_state?(TCPI.get!(socket).state)
         else
           write_http_header(socket)
@@ -160,7 +160,7 @@ module Pitchfork
         if TCPSocket === socket && @@tcpi_inspect_ok
           opt = socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO).inspect
           if opt =~ /\bstate=(\S+)/
-            raise Errno::EPIPE, "client closed connection".freeze,
+            raise Errno::EPIPE, "client closed connection",
                   EMPTY_ARRAY if closed_state_str?($1)
           else
             @@tcpi_inspect_ok = false

--- a/lib/pitchfork/http_response.rb
+++ b/lib/pitchfork/http_response.rb
@@ -65,7 +65,7 @@ module Pitchfork
             append_header(buf, key, value)
           end
         end
-        socket.write(buf << "\r\n".freeze)
+        socket.write(buf << "\r\n")
       end
 
       if hijack

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -675,18 +675,14 @@ module Pitchfork
       rss = @request.response_start_sent
       buf = (rss ? "103 Early Hints\r\n" : "HTTP/1.1 103 Early Hints\r\n").b
       headers.each { |key, value| append_header(buf, key, value) }
-      buf << (rss ? "\r\nHTTP/1.1 ".freeze : "\r\n".freeze)
+      buf << (rss ? "\r\nHTTP/1.1 " : "\r\n")
       client.write(buf)
     end
 
     def e100_response_write(client, env)
-      # We use String#freeze to avoid allocations under Ruby 2.1+
-      # Not many users hit this code path, so it's better to reduce the
-      # constant table sizes even for Ruby 2.0 users who'll hit extra
-      # allocations here.
       client.write(@request.response_start_sent ?
-                   "100 Continue\r\n\r\nHTTP/1.1 ".freeze :
-                   "HTTP/1.1 100 Continue\r\n\r\n".freeze)
+                   "100 Continue\r\n\r\nHTTP/1.1 " :
+                   "HTTP/1.1 100 Continue\r\n\r\n")
       env.delete('HTTP_EXPECT')
     end
 

--- a/lib/pitchfork/socket_helper.rb
+++ b/lib/pitchfork/socket_helper.rb
@@ -72,7 +72,7 @@ module Pitchfork
         rescue => e
           logger.error("#{sock_name(sock)} " \
                        "failed to set accept_filter=#{name} (#{e.inspect})")
-          logger.error("perhaps accf_http(9) needs to be loaded".freeze)
+          logger.error("perhaps accf_http(9) needs to be loaded")
         end if arg != got
       end
     end

--- a/test/unit/test_http_parser_ng.rb
+++ b/test/unit/test_http_parser_ng.rb
@@ -67,7 +67,7 @@ module Pitchfork
     end
 
     def test_keepalive_requests_with_next?
-      req = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".freeze
+      req = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
       expect = {
         "SERVER_NAME" => "example.com",
         "HTTP_HOST" => "example.com",
@@ -362,7 +362,7 @@ module Pitchfork
       rv = @parser.filter_body(tmp, str)
       assert_equal rv.object_id, str.object_id
       assert_equal '', str
-      md5_hdr = "Content-MD5: #{md5_b64}\r\n".freeze
+      md5_hdr = "Content-MD5: #{md5_b64}\r\n"
       str << md5_hdr
       assert_nil @parser.trailers(req, str)
       assert_equal md5_b64, req['HTTP_CONTENT_MD5']
@@ -393,7 +393,7 @@ module Pitchfork
       assert_equal rv.object_id, str.object_id
       assert_equal '', str
       assert_nil @parser.trailers(req, str)
-      md5_hdr = "Content-MD5: #{md5_b64}\r\n".freeze
+      md5_hdr = "Content-MD5: #{md5_b64}\r\n"
       md5_hdr.each_byte { |byte|
         str << byte.chr
         assert_nil @parser.trailers(req, str)

--- a/test/unit/test_socket_helper.rb
+++ b/test/unit/test_socket_helper.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 class TestSocketHelper < Pitchfork::Test
   include Pitchfork::SocketHelper
   attr_reader :logger
-  GET_SLASH = "GET / HTTP/1.0\r\n\r\n".freeze
+  GET_SLASH = "GET / HTTP/1.0\r\n\r\n"
 
   def setup
     @log_tmp = Tempfile.new 'logger'


### PR DESCRIPTION
All files now have the frozen string literal comment. Followup #119

I force-pushed before reopening, classic mistake. Now the banch name is correct at least.