### PR TITLE
Implement service workers

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -422,6 +422,39 @@ after_request_complete do |server, worker, env|
 end
 ```
 
+### `before_service_worker_ready` (experimental)
+
+Experimental and may change at any point.
+
+If defined, Pitchfork will spawn one extra worker, called a service worker
+which doesn't accept incoming requests, but allows to perform service tasks
+such as warming node local caches or emitting metrics.
+
+Service workers are never promoted to molds, so it is safe to use threads and
+other fork unsafe APIs.
+
+This callback MUST not block. It should start one or multiple background threads
+to perform tasks at regular intervals.
+
+```ruby
+before_service_worker_ready do |server, service_worker|
+  Thread.new do
+    loop do
+      MyApp.emit_utilization_metrics
+      sleep 1
+    end
+  end
+end
+```
+
+### `before_service_worker_exit` (experimental)
+
+Experimental and may change at any point.
+
+Optional.
+
+Called whenever the service worker is exiting. This allow to do a clean shutdown.
+
 ## Reforking
 
 ### `refork_after`

--- a/examples/pitchfork.conf.service.rb
+++ b/examples/pitchfork.conf.service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# Minimal sample configuration file for Pitchfork
+
+# listen 2007 # by default Pitchfork listens on port 8080
+worker_processes 4 # this should be >= nr_cpus
+refork_after [50, 100, 1000]
+
+service_thread = nil
+service_shutdown = false
+
+before_service_worker_ready do |server, service|
+  service_thread = Thread.new do
+    server.logger.info "Service: start"
+    count = 1
+    until service_shutdown
+      server.logger.info "Service: ping count=#{count}"
+      count += 1
+      sleep 1
+    end
+  end
+end
+
+before_service_worker_exit do |server, service|
+  server.logger.info "Service: shutting down"
+  service_shutdown = true
+  service_thread&.join(2)
+end

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -52,6 +52,8 @@ module Pitchfork
           "repead unknown process (#{status.inspect})"
         elsif worker.mold?
           "mold pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
+        elsif worker.service?
+          "service pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
         else
           "worker=#{worker.nr rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
         end
@@ -75,6 +77,8 @@ module Pitchfork
       :check_client_connection => false,
       :rewindable_input => true,
       :client_body_buffer_size => Pitchfork::Const::MAX_BODY,
+      :before_service_worker_ready => nil,
+      :before_service_worker_exit => nil,
     }
     #:startdoc:
 
@@ -174,6 +178,14 @@ module Pitchfork
 
     def after_request_complete(*args, &block)
       set_hook(:after_request_complete, block_given? ? block : args[0], 3)
+    end
+
+    def before_service_worker_ready(&block)
+      set_hook(:before_service_worker_ready, block, 2)
+    end
+
+    def before_service_worker_exit(&block)
+      set_hook(:before_service_worker_exit, block, 2)
     end
 
     def timeout(seconds, cleanup: 2)

--- a/lib/pitchfork/message.rb
+++ b/lib/pitchfork/message.rb
@@ -122,12 +122,16 @@ module Pitchfork
 
   Message = Class.new(Struct)
   class Message
-    SpawnWorker = Message.new(:nr)
-    WorkerSpawned = Message.new(:nr, :pid, :generation, :pipe)
-    PromoteWorker = Message.new(:generation)
-    MoldSpawned = Message.new(:nr, :pid, :generation, :pipe)
-    MoldReady = Message.new(:nr, :pid, :generation)
+    SpawnWorker = new(:nr)
+    WorkerSpawned = new(:nr, :pid, :generation, :pipe)
+    PromoteWorker = new(:generation)
 
-    SoftKill = Message.new(:signum)
+    MoldSpawned = new(:nr, :pid, :generation, :pipe)
+    MoldReady = new(:nr, :pid, :generation)
+
+    SpawnService = new(:_) # Struct.new requires at least 1 member on Ruby < 3.3
+    ServiceSpawned = new(:pid, :generation, :pipe)
+
+    SoftKill = new(:signum)
   end
 end

--- a/lib/pitchfork/shared_memory.rb
+++ b/lib/pitchfork/shared_memory.rb
@@ -11,7 +11,8 @@ module Pitchfork
     SHUTDOWN_OFFSET = 1
     MOLD_TICK_OFFSET = 2
     MOLD_PROMOTION_TICK_OFFSET = 3
-    WORKER_TICK_OFFSET = 4
+    SERVICE_TICK_OFFSET = 4
+    WORKER_TICK_OFFSET = 5
 
     DROPS = [Raindrops.new(PER_DROP)]
 
@@ -52,6 +53,10 @@ module Pitchfork
 
     def mold_promotion_deadline
       self[MOLD_PROMOTION_TICK_OFFSET]
+    end
+
+    def service_deadline
+      self[SERVICE_TICK_OFFSET]
     end
 
     def worker_deadline(worker_nr)

--- a/test/integration/test_service_worker.rb
+++ b/test/integration/test_service_worker.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'integration_test_helper'
+
+class ServiceWorkerTest < Pitchfork::IntegrationTest
+  def test_start_and_exit
+    addr, port = unused_port
+
+    pid = spawn_server(app: File.join(ROOT, "test/integration/env.ru"), config: <<~CONFIG)
+      listen "#{addr}:#{port}"
+      worker_processes 1
+
+      service_thread = nil
+      service_shutdown = false
+
+      before_service_worker_ready do |server, service|
+        service_thread = Thread.new do
+          $stderr.puts "[service] start"
+          count = 1
+          until service_shutdown
+            $stderr.puts "[service] ping count=\#{count}"
+            count += 1
+            sleep 1
+          end
+        end
+      end
+
+      before_service_worker_exit do |server, service|
+        $stderr.puts "[service] exit"
+        service_shutdown = true
+        service_thread&.join(2)
+      end
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+    assert_stderr("[service] start")
+    assert_stderr("[service] ping count=1")
+    assert_stderr("[service] ping count=2")
+    assert_clean_shutdown(pid)
+    assert_stderr("[service] exit")
+  end
+
+  def test_start_only
+    addr, port = unused_port
+
+    pid = spawn_server(app: File.join(ROOT, "test/integration/env.ru"), config: <<~CONFIG)
+      listen "#{addr}:#{port}"
+      worker_processes 1
+
+      before_service_worker_ready do |server, service|
+        Thread.new do
+          $stderr.puts "[service] start"
+          count = 1
+          loop do
+            $stderr.puts "[service] ping count=\#{count}"
+            count += 1
+            sleep 1
+          end
+        end
+      end
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+    assert_stderr("[service] start")
+    assert_stderr("[service] ping count=1")
+    assert_stderr("[service] ping count=2")
+    assert_clean_shutdown(pid)
+  end
+end


### PR DESCRIPTION
Ref: https://github.com/Shopify/pitchfork/issues/110

It's not uncommon for applications to want to have some background threads doing regular work for various purposes (e.g. emitting metrics, prewarming node local caches, etc).

Currently the best way to do it, is to spawn some background threads in the `after_mold_fork`, but this isn't great as the mold may fork at any moment to spawn a new worker, and forking while background threads may be doing work is risky.

Instead we can provide a dedicated service worker process to run these threads.