### PR TITLE
Mark Waiter.prep_readers return value as safe to keep

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -804,7 +804,7 @@ module Pitchfork
 
     if Pitchfork.const_defined?(:Waiter)
       def prep_readers(readers)
-        Pitchfork::Waiter.prep_readers(readers)
+        Pitchfork::Info.keep_io(Pitchfork::Waiter.prep_readers(readers))
       end
     else
       require_relative 'select_waiter'


### PR DESCRIPTION
The returned object is an IO subclass, and shouldn't be closed by `close_all_ios!`.