### PR TITLE
Eliminate dependency on Raindrops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Remove the dependency on `raindrops`.
 - Add `X-Request-Id` header in the workers proctitle if present.
 
 # 0.13.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     pitchfork (0.13.0)
       rack (>= 2.0)
-      raindrops (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +12,6 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     rack (3.0.10)
-    raindrops (0.20.1)
     rake (13.0.6)
     rake-compiler (1.2.1)
       rake

--- a/ext/pitchfork_http/extconf.rb
+++ b/ext/pitchfork_http/extconf.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 require 'mkmf'
 
+append_cflags("-fvisibility=hidden")
 have_const("PR_SET_CHILD_SUBREAPER", "sys/prctl.h")
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_io_descriptor", "ruby.h") # Ruby 3.1+

--- a/ext/pitchfork_http/extconf.rb
+++ b/ext/pitchfork_http/extconf.rb
@@ -6,6 +6,7 @@ append_cflags("-fvisibility=hidden")
 have_const("PR_SET_CHILD_SUBREAPER", "sys/prctl.h")
 have_func("rb_enc_interned_str", "ruby.h") # Ruby 3.0+
 have_func("rb_io_descriptor", "ruby.h") # Ruby 3.1+
+have_func("getpagesize", "unistd.h")
 
 if RUBY_VERSION.start_with?('3.0.')
   # https://bugs.ruby-lang.org/issues/18772

--- a/ext/pitchfork_http/memory_page.c
+++ b/ext/pitchfork_http/memory_page.c
@@ -1,0 +1,223 @@
+/* Note: A large part of this code has been borrowed/stolen/adapted from raindrops. */
+
+#include <ruby.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+
+#define PAGE_MASK               (~(page_size - 1))
+#define PAGE_ALIGN(addr)        (((addr) + page_size - 1) & PAGE_MASK)
+
+static size_t slot_size = 128;
+
+static void init_slot_size(void)
+{
+    long tmp = 2;
+
+#ifdef _SC_NPROCESSORS_CONF
+    tmp = sysconf(_SC_NPROCESSORS_CONF);
+#endif
+    /* no point in padding on single CPU machines */
+    if (tmp == 1) {
+        slot_size = sizeof(unsigned long);
+    }
+#ifdef _SC_LEVEL1_DCACHE_LINESIZE
+    if (tmp != 1) {
+        tmp = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+        if (tmp > 0) {
+            slot_size = (size_t)tmp;
+        }
+    }
+#endif
+}
+
+static size_t page_size = (size_t)-1;
+
+static void init_page_size(void)
+{
+#if defined(_SC_PAGE_SIZE)
+    page_size = (size_t)sysconf(_SC_PAGE_SIZE);
+#elif defined(_SC_PAGESIZE)
+    page_size = (size_t)sysconf(_SC_PAGESIZE);
+#elif defined(HAVE_GETPAGESIZE)
+    page_size = (size_t)getpagesize();
+#elif defined(PAGE_SIZE)
+    page_size = (size_t)PAGE_SIZE;
+#elif defined(PAGESIZE)
+    page_size = (size_t)PAGESIZE;
+#else
+#  error unable to detect page size for mmap()
+#endif
+    if ((page_size == (size_t)-1) || (page_size < slot_size)) {
+        rb_raise(rb_eRuntimeError, "system page size invalid: %llu", (unsigned long long)page_size);
+    }
+}
+
+/* each slot is a counter */
+struct slot {
+    unsigned long counter;
+} __attribute__((packed));
+
+/* allow mmap-ed regions to store more than one counter */
+struct memory_page {
+    size_t size;
+    size_t capa;
+    struct slot *slots;
+};
+
+static void memory_page_free(void *ptr)
+{
+    struct memory_page *page = (struct memory_page *)ptr;
+
+    if (page->slots != MAP_FAILED) {
+        int rv = munmap(page->slots, slot_size * page->capa);
+        if (rv != 0) {
+            rb_bug("Pitchfork::MemoryPage munmap failed in gc: %s", strerror(errno));
+        }
+    }
+
+    xfree(ptr);
+}
+
+static size_t memory_page_memsize(const void *ptr)
+{
+    const struct memory_page *page = (const struct memory_page *)ptr;
+    size_t memsize = sizeof(struct memory_page);
+    if (page->slots != MAP_FAILED) {
+        memsize += slot_size * page->capa;
+    }
+    return memsize;
+}
+
+static const rb_data_type_t memory_page_type = {
+    .wrap_struct_name = "Pitchfork::MemoryPage",
+    .function = {
+        .dmark = NULL,
+        .dfree = memory_page_free,
+        .dsize = memory_page_memsize,
+    },
+    .flags = RUBY_TYPED_WB_PROTECTED,
+};
+
+static VALUE memory_page_alloc(VALUE klass)
+{
+    struct memory_page *page;
+    VALUE obj = TypedData_Make_Struct(klass, struct memory_page, &memory_page_type, page);
+
+    page->slots = MAP_FAILED;
+    return obj;
+}
+
+static struct memory_page *memory_page_get(VALUE self)
+{
+    struct memory_page *page;
+
+    TypedData_Get_Struct(self, struct memory_page, &memory_page_type, page);
+
+    if (page->slots == MAP_FAILED) {
+        rb_raise(rb_eStandardError, "invalid or freed Pitchfork::MemoryPage");
+    }
+
+    return page;
+}
+
+static unsigned long *memory_page_address(VALUE self, VALUE index)
+{
+    struct memory_page *page = memory_page_get(self);
+    unsigned long off = FIX2ULONG(index) * slot_size;
+
+    if (off >= slot_size * page->size) {
+        rb_raise(rb_eArgError, "offset overrun");
+    }
+
+    return (unsigned long *)((unsigned long)page->slots + off);
+}
+
+
+static VALUE memory_page_aref(VALUE self, VALUE index)
+{
+    return ULONG2NUM(*memory_page_address(self, index));
+}
+
+static VALUE memory_page_aset(VALUE self, VALUE index, VALUE value)
+{
+    unsigned long *addr = memory_page_address(self, index);
+    *addr = NUM2ULONG(value);
+    return value;
+}
+
+static VALUE memory_page_initialize(VALUE self, VALUE size)
+{
+    struct memory_page *page;
+    TypedData_Get_Struct(self, struct memory_page, &memory_page_type, page);
+
+    int tries = 1;
+
+    if (page->slots != MAP_FAILED) {
+        rb_raise(rb_eRuntimeError, "already initialized");
+    }
+
+    page->size = NUM2SIZET(size);
+    if (page->size < 1) {
+        rb_raise(rb_eArgError, "size must be >= 1");
+    }
+
+    size_t tmp = PAGE_ALIGN(slot_size * page->size);
+    page->capa = tmp / slot_size;
+    assert(PAGE_ALIGN(slot_size * page->capa) == tmp && "not aligned");
+
+retry:
+    page->slots = mmap(NULL, tmp, PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, -1, 0);
+
+    if (page->slots == MAP_FAILED) {
+        int err = errno;
+
+        if ((err == EAGAIN || err == ENOMEM) && tries-- > 0) {
+            rb_gc();
+            goto retry;
+        }
+        rb_sys_fail("mmap");
+    }
+
+    memset(page->slots, 0, tmp);
+
+    return self;
+}
+
+void init_pitchfork_memory_page(VALUE mPitchfork)
+{
+    init_slot_size();
+    init_page_size();
+
+    VALUE rb_cMemoryPage = rb_define_class_under(mPitchfork, "MemoryPage", rb_cObject);
+
+    /*
+     * The size of one page of memory for a mmap()-ed MemoryPage region.
+     * Typically 4096 bytes under Linux.
+     */
+    rb_define_const(rb_cMemoryPage, "PAGE_SIZE", SIZET2NUM(page_size));
+
+    /*
+     * The size (in bytes) of a slot in a MemoryPage object.
+     * This is the size of a word on single CPU systems and
+     * the size of the L1 cache line size if detectable.
+     *
+     * Defaults to 128 bytes if undetectable.
+     */
+    rb_define_const(rb_cMemoryPage, "SLOT_SIZE", SIZET2NUM(slot_size));
+
+    rb_define_const(rb_cMemoryPage, "SLOTS", SIZET2NUM(page_size / slot_size));
+
+    /*
+     * The maximum value a slot counter can hold
+     */
+    rb_define_const(rb_cMemoryPage, "SLOT_MAX", ULONG2NUM((unsigned long)-1));
+
+    rb_define_alloc_func(rb_cMemoryPage, memory_page_alloc);
+    rb_define_private_method(rb_cMemoryPage, "initialize", memory_page_initialize, 1);
+    rb_define_method(rb_cMemoryPage, "[]", memory_page_aref, 1);
+    rb_define_method(rb_cMemoryPage, "[]=", memory_page_aset, 2);
+}

--- a/ext/pitchfork_http/pitchfork_http.c
+++ b/ext/pitchfork_http/pitchfork_http.c
@@ -18,6 +18,7 @@
 #include "child_subreaper.h"
 
 void init_pitchfork_httpdate(void);
+void init_pitchfork_memory_page(VALUE);
 
 #define UH_FL_CHUNKED  0x1
 #define UH_FL_HASBODY  0x2
@@ -314,12 +315,12 @@ static void write_value(VALUE self, struct http_parser *hp,
 /** Machine **/
 
 
-#line 421 "pitchfork_http.rl"
+#line 422 "pitchfork_http.rl"
 
 
 /** Data **/
 
-#line 323 "pitchfork_http.c"
+#line 324 "pitchfork_http.c"
 static const int http_parser_start = 1;
 static const int http_parser_first_final = 122;
 static const int http_parser_error = 0;
@@ -330,7 +331,7 @@ static const int http_parser_en_Trailers = 114;
 static const int http_parser_en_main = 1;
 
 
-#line 425 "pitchfork_http.rl"
+#line 426 "pitchfork_http.rl"
 
 static void http_parser_init(struct http_parser *hp)
 {
@@ -343,12 +344,12 @@ static void http_parser_init(struct http_parser *hp)
   hp->len.content = 0;
   hp->cont = Qfalse; /* zero on MRI, should be optimized away by above */
   
-#line 347 "pitchfork_http.c"
+#line 348 "pitchfork_http.c"
 	{
 	cs = http_parser_start;
 	}
 
-#line 437 "pitchfork_http.rl"
+#line 438 "pitchfork_http.rl"
   hp->cs = cs;
 }
 
@@ -376,7 +377,7 @@ http_parser_execute(VALUE self, struct http_parser *hp, char *buffer, size_t len
     goto skip_chunk_data_hack;
   }
   
-#line 380 "pitchfork_http.c"
+#line 381 "pitchfork_http.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -411,14 +412,14 @@ st0:
 cs = 0;
 	goto _out;
 tr0:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st2;
 st2:
 	if ( ++p == pe )
 		goto _test_eof2;
 case 2:
-#line 422 "pitchfork_http.c"
+#line 423 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr3;
 		case 33: goto st49;
@@ -444,14 +445,14 @@ case 2:
 		goto st49;
 	goto st0;
 tr3:
-#line 326 "pitchfork_http.rl"
+#line 327 "pitchfork_http.rl"
 	{ request_method(hp, PTR_TO(mark), LEN(mark, p)); }
 	goto st3;
 st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 455 "pitchfork_http.c"
+#line 456 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 42: goto tr5;
 		case 47: goto tr6;
@@ -460,21 +461,21 @@ case 3:
 	}
 	goto st0;
 tr5:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 471 "pitchfork_http.c"
+#line 472 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr8;
 		case 35: goto tr9;
 	}
 	goto st0;
 tr8:
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -492,23 +493,23 @@ tr8:
   }
 	goto st5;
 tr42:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
 	goto st5;
 tr45:
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
 	goto st5;
 tr49:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -519,7 +520,7 @@ tr49:
     if (!STR_CSTR_EQ(val, "*"))
       rb_hash_aset(hp->env, g_path_info, val);
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -537,14 +538,14 @@ tr49:
   }
 	goto st5;
 tr55:
-#line 350 "pitchfork_http.rl"
-	{MARK(start.query, p); }
 #line 351 "pitchfork_http.rl"
+	{MARK(start.query, p); }
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -562,12 +563,12 @@ tr55:
   }
 	goto st5;
 tr59:
-#line 351 "pitchfork_http.rl"
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -588,19 +589,19 @@ st5:
 	if ( ++p == pe )
 		goto _test_eof5;
 case 5:
-#line 592 "pitchfork_http.c"
+#line 593 "pitchfork_http.c"
 	if ( (*p) == 72 )
 		goto tr10;
 	goto st0;
 tr10:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st6;
 st6:
 	if ( ++p == pe )
 		goto _test_eof6;
 case 6:
-#line 604 "pitchfork_http.c"
+#line 605 "pitchfork_http.c"
 	if ( (*p) == 84 )
 		goto st7;
 	goto st0;
@@ -660,34 +661,34 @@ case 13:
 		goto st13;
 	goto st0;
 tr18:
-#line 355 "pitchfork_http.rl"
+#line 356 "pitchfork_http.rl"
 	{ http_version(hp, PTR_TO(mark), LEN(mark, p)); }
 	goto st14;
 tr26:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st14;
 tr29:
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st14;
 tr36:
-#line 323 "pitchfork_http.rl"
-	{ MARK(mark, p); }
 #line 324 "pitchfork_http.rl"
+	{ MARK(mark, p); }
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st14;
 tr39:
-#line 324 "pitchfork_http.rl"
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st14;
 st14:
 	if ( ++p == pe )
 		goto _test_eof14;
 case 14:
-#line 691 "pitchfork_http.c"
+#line 692 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto st15;
 		case 10: goto tr21;
@@ -716,14 +717,14 @@ case 14:
 		goto tr23;
 	goto st0;
 tr25:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st15;
 st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 727 "pitchfork_http.c"
+#line 728 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto tr25;
 		case 10: goto tr26;
@@ -735,14 +736,14 @@ case 15:
 		goto st0;
 	goto tr24;
 tr24:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st16;
 st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 746 "pitchfork_http.c"
+#line 747 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr29;
 		case 13: goto tr30;
@@ -755,39 +756,39 @@ case 16:
 		goto st0;
 	goto st16;
 tr19:
-#line 355 "pitchfork_http.rl"
+#line 356 "pitchfork_http.rl"
 	{ http_version(hp, PTR_TO(mark), LEN(mark, p)); }
 	goto st17;
 tr27:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st17;
 tr30:
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st17;
 tr37:
-#line 323 "pitchfork_http.rl"
-	{ MARK(mark, p); }
 #line 324 "pitchfork_http.rl"
+	{ MARK(mark, p); }
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st17;
 tr40:
-#line 324 "pitchfork_http.rl"
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 786 "pitchfork_http.c"
+#line 787 "pitchfork_http.c"
 	if ( (*p) == 10 )
 		goto st14;
 	goto st0;
 tr21:
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -808,7 +809,7 @@ tr21:
   }
 	goto st122;
 tr104:
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -824,7 +825,7 @@ tr104:
       rb_hash_aset(hp->env, g_request_path, str);
     }
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -845,14 +846,14 @@ tr104:
   }
 	goto st122;
 tr108:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -873,12 +874,12 @@ tr108:
   }
 	goto st122;
 tr112:
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -899,7 +900,7 @@ tr112:
   }
 	goto st122;
 tr117:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -910,7 +911,7 @@ tr117:
     if (!STR_CSTR_EQ(val, "*"))
       rb_hash_aset(hp->env, g_path_info, val);
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -926,7 +927,7 @@ tr117:
       rb_hash_aset(hp->env, g_request_path, str);
     }
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -947,14 +948,14 @@ tr117:
   }
 	goto st122;
 tr124:
-#line 350 "pitchfork_http.rl"
-	{MARK(start.query, p); }
 #line 351 "pitchfork_http.rl"
+	{MARK(start.query, p); }
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -970,7 +971,7 @@ tr124:
       rb_hash_aset(hp->env, g_request_path, str);
     }
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -991,12 +992,12 @@ tr124:
   }
 	goto st122;
 tr129:
-#line 351 "pitchfork_http.rl"
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1012,7 +1013,7 @@ tr129:
       rb_hash_aset(hp->env, g_request_path, str);
     }
   }
-#line 371 "pitchfork_http.rl"
+#line 372 "pitchfork_http.rl"
 	{
     finalize_header(hp);
 
@@ -1036,10 +1037,10 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 1040 "pitchfork_http.c"
+#line 1041 "pitchfork_http.c"
 	goto st0;
 tr105:
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1057,23 +1058,23 @@ tr105:
   }
 	goto st18;
 tr109:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
 	goto st18;
 tr113:
-#line 346 "pitchfork_http.rl"
+#line 347 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(mark, p), FRAGMENT);
     rb_hash_aset(hp->env, g_fragment, STR_NEW(mark, p));
   }
 	goto st18;
 tr118:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -1084,7 +1085,7 @@ tr118:
     if (!STR_CSTR_EQ(val, "*"))
       rb_hash_aset(hp->env, g_path_info, val);
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1102,14 +1103,14 @@ tr118:
   }
 	goto st18;
 tr125:
-#line 350 "pitchfork_http.rl"
-	{MARK(start.query, p); }
 #line 351 "pitchfork_http.rl"
+	{MARK(start.query, p); }
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1127,12 +1128,12 @@ tr125:
   }
 	goto st18;
 tr130:
-#line 351 "pitchfork_http.rl"
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1153,25 +1154,25 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1157 "pitchfork_http.c"
+#line 1158 "pitchfork_http.c"
 	if ( (*p) == 10 )
 		goto tr21;
 	goto st0;
 tr23:
-#line 319 "pitchfork_http.rl"
-	{ MARK(start.field, p); }
 #line 320 "pitchfork_http.rl"
+	{ MARK(start.field, p); }
+#line 321 "pitchfork_http.rl"
 	{ snake_upcase_char(deconst(p)); }
 	goto st19;
 tr32:
-#line 320 "pitchfork_http.rl"
+#line 321 "pitchfork_http.rl"
 	{ snake_upcase_char(deconst(p)); }
 	goto st19;
 st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1175 "pitchfork_http.c"
+#line 1176 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 33: goto tr32;
 		case 58: goto tr33;
@@ -1197,18 +1198,18 @@ case 19:
 		goto tr32;
 	goto st0;
 tr35:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st20;
 tr33:
-#line 322 "pitchfork_http.rl"
+#line 323 "pitchfork_http.rl"
 	{ hp->s.field_len = LEN(start.field, p); }
 	goto st20;
 st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1212 "pitchfork_http.c"
+#line 1213 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto tr35;
 		case 10: goto tr36;
@@ -1220,14 +1221,14 @@ case 20:
 		goto st0;
 	goto tr34;
 tr34:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st21;
 st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1231 "pitchfork_http.c"
+#line 1232 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr39;
 		case 13: goto tr40;
@@ -1240,7 +1241,7 @@ case 21:
 		goto st0;
 	goto st21;
 tr9:
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1258,7 +1259,7 @@ tr9:
   }
 	goto st22;
 tr50:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -1269,7 +1270,7 @@ tr50:
     if (!STR_CSTR_EQ(val, "*"))
       rb_hash_aset(hp->env, g_path_info, val);
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1287,14 +1288,14 @@ tr50:
   }
 	goto st22;
 tr56:
-#line 350 "pitchfork_http.rl"
-	{MARK(start.query, p); }
 #line 351 "pitchfork_http.rl"
+	{MARK(start.query, p); }
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1312,12 +1313,12 @@ tr56:
   }
 	goto st22;
 tr60:
-#line 351 "pitchfork_http.rl"
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -1338,7 +1339,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1342 "pitchfork_http.c"
+#line 1343 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr42;
 		case 35: goto st0;
@@ -1349,14 +1350,14 @@ case 22:
 		goto st0;
 	goto tr41;
 tr41:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st23;
 st23:
 	if ( ++p == pe )
 		goto _test_eof23;
 case 23:
-#line 1360 "pitchfork_http.c"
+#line 1361 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr45;
 		case 35: goto st0;
@@ -1367,14 +1368,14 @@ case 23:
 		goto st0;
 	goto st23;
 tr43:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st24;
 st24:
 	if ( ++p == pe )
 		goto _test_eof24;
 case 24:
-#line 1378 "pitchfork_http.c"
+#line 1379 "pitchfork_http.c"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto st25;
@@ -1398,20 +1399,20 @@ case 25:
 		goto st23;
 	goto st0;
 tr6:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st26;
 tr76:
-#line 330 "pitchfork_http.rl"
+#line 331 "pitchfork_http.rl"
 	{ rb_hash_aset(hp->env, g_http_host, STR_NEW(mark, p)); }
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st26;
 st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1415 "pitchfork_http.c"
+#line 1416 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr49;
 		case 35: goto tr50;
@@ -1449,7 +1450,7 @@ case 28:
 		goto st26;
 	goto st0;
 tr52:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -1465,7 +1466,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1469 "pitchfork_http.c"
+#line 1470 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr55;
 		case 35: goto tr56;
@@ -1476,14 +1477,14 @@ case 29:
 		goto st0;
 	goto tr54;
 tr54:
-#line 350 "pitchfork_http.rl"
+#line 351 "pitchfork_http.rl"
 	{MARK(start.query, p); }
 	goto st30;
 st30:
 	if ( ++p == pe )
 		goto _test_eof30;
 case 30:
-#line 1487 "pitchfork_http.c"
+#line 1488 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr59;
 		case 35: goto tr60;
@@ -1494,14 +1495,14 @@ case 30:
 		goto st0;
 	goto st30;
 tr57:
-#line 350 "pitchfork_http.rl"
+#line 351 "pitchfork_http.rl"
 	{MARK(start.query, p); }
 	goto st31;
 st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1505 "pitchfork_http.c"
+#line 1506 "pitchfork_http.c"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto st32;
@@ -1525,58 +1526,58 @@ case 32:
 		goto st30;
 	goto st0;
 tr7:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st33;
 st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 1538 "pitchfork_http.c"
+#line 1539 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 84: goto tr63;
 		case 116: goto tr63;
 	}
 	goto st0;
 tr63:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st34;
 st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 1552 "pitchfork_http.c"
+#line 1553 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 84: goto tr64;
 		case 116: goto tr64;
 	}
 	goto st0;
 tr64:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st35;
 st35:
 	if ( ++p == pe )
 		goto _test_eof35;
 case 35:
-#line 1566 "pitchfork_http.c"
+#line 1567 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 80: goto tr65;
 		case 112: goto tr65;
 	}
 	goto st0;
 tr65:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st36;
 st36:
 	if ( ++p == pe )
 		goto _test_eof36;
 case 36:
-#line 1580 "pitchfork_http.c"
+#line 1581 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 58: goto tr66;
 		case 83: goto tr67;
@@ -1584,7 +1585,7 @@ case 36:
 	}
 	goto st0;
 tr66:
-#line 327 "pitchfork_http.rl"
+#line 328 "pitchfork_http.rl"
 	{
     rb_hash_aset(hp->env, g_rack_url_scheme, STR_NEW(mark, p));
   }
@@ -1593,7 +1594,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 1597 "pitchfork_http.c"
+#line 1598 "pitchfork_http.c"
 	if ( (*p) == 47 )
 		goto st38;
 	goto st0;
@@ -1681,14 +1682,14 @@ case 42:
 		goto st40;
 	goto st0;
 tr72:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st43;
 st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 1692 "pitchfork_http.c"
+#line 1693 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 37: goto st41;
 		case 47: goto tr76;
@@ -1740,14 +1741,14 @@ case 44:
 		goto st0;
 	goto st40;
 tr73:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st45;
 st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 1751 "pitchfork_http.c"
+#line 1752 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 37: goto st41;
 		case 47: goto st0;
@@ -1825,14 +1826,14 @@ case 47:
 		goto st0;
 	goto st40;
 tr67:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st48;
 st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 1836 "pitchfork_http.c"
+#line 1837 "pitchfork_http.c"
 	if ( (*p) == 58 )
 		goto tr66;
 	goto st0;
@@ -2348,14 +2349,14 @@ case 67:
 		goto tr3;
 	goto st0;
 tr2:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st68;
 st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 2359 "pitchfork_http.c"
+#line 2360 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 32: goto tr3;
 		case 33: goto st49;
@@ -2439,14 +2440,14 @@ case 70:
 		goto st51;
 	goto st0;
 tr100:
-#line 326 "pitchfork_http.rl"
+#line 327 "pitchfork_http.rl"
 	{ request_method(hp, PTR_TO(mark), LEN(mark, p)); }
 	goto st71;
 st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 2450 "pitchfork_http.c"
+#line 2451 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 42: goto tr101;
 		case 47: goto tr102;
@@ -2455,14 +2456,14 @@ case 71:
 	}
 	goto st0;
 tr101:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st72;
 st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 2466 "pitchfork_http.c"
+#line 2467 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr104;
 		case 13: goto tr105;
@@ -2471,7 +2472,7 @@ case 72:
 	}
 	goto st0;
 tr106:
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -2489,7 +2490,7 @@ tr106:
   }
 	goto st73;
 tr119:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -2500,7 +2501,7 @@ tr119:
     if (!STR_CSTR_EQ(val, "*"))
       rb_hash_aset(hp->env, g_path_info, val);
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -2518,14 +2519,14 @@ tr119:
   }
 	goto st73;
 tr126:
-#line 350 "pitchfork_http.rl"
-	{MARK(start.query, p); }
 #line 351 "pitchfork_http.rl"
+	{MARK(start.query, p); }
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -2543,12 +2544,12 @@ tr126:
   }
 	goto st73;
 tr131:
-#line 351 "pitchfork_http.rl"
+#line 352 "pitchfork_http.rl"
 	{
     VALIDATE_MAX_URI_LENGTH(LEN(start.query, p), QUERY_STRING);
     rb_hash_aset(hp->env, g_query_string, STR_NEW(start.query, p));
   }
-#line 331 "pitchfork_http.rl"
+#line 332 "pitchfork_http.rl"
 	{
     VALUE str;
 
@@ -2569,7 +2570,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 2573 "pitchfork_http.c"
+#line 2574 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr108;
 		case 13: goto tr109;
@@ -2582,14 +2583,14 @@ case 73:
 		goto st0;
 	goto tr107;
 tr107:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st74;
 st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 2593 "pitchfork_http.c"
+#line 2594 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr112;
 		case 13: goto tr113;
@@ -2602,14 +2603,14 @@ case 74:
 		goto st0;
 	goto st74;
 tr110:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st75;
 st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 2613 "pitchfork_http.c"
+#line 2614 "pitchfork_http.c"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto st76;
@@ -2633,20 +2634,20 @@ case 76:
 		goto st74;
 	goto st0;
 tr102:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st77;
 tr147:
-#line 330 "pitchfork_http.rl"
+#line 331 "pitchfork_http.rl"
 	{ rb_hash_aset(hp->env, g_http_host, STR_NEW(mark, p)); }
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st77;
 st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 2650 "pitchfork_http.c"
+#line 2651 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr117;
 		case 13: goto tr118;
@@ -2686,7 +2687,7 @@ case 79:
 		goto st77;
 	goto st0;
 tr121:
-#line 356 "pitchfork_http.rl"
+#line 357 "pitchfork_http.rl"
 	{
     VALUE val;
 
@@ -2702,7 +2703,7 @@ st80:
 	if ( ++p == pe )
 		goto _test_eof80;
 case 80:
-#line 2706 "pitchfork_http.c"
+#line 2707 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr124;
 		case 13: goto tr125;
@@ -2715,14 +2716,14 @@ case 80:
 		goto st0;
 	goto tr123;
 tr123:
-#line 350 "pitchfork_http.rl"
+#line 351 "pitchfork_http.rl"
 	{MARK(start.query, p); }
 	goto st81;
 st81:
 	if ( ++p == pe )
 		goto _test_eof81;
 case 81:
-#line 2726 "pitchfork_http.c"
+#line 2727 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr129;
 		case 13: goto tr130;
@@ -2735,14 +2736,14 @@ case 81:
 		goto st0;
 	goto st81;
 tr127:
-#line 350 "pitchfork_http.rl"
+#line 351 "pitchfork_http.rl"
 	{MARK(start.query, p); }
 	goto st82;
 st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 2746 "pitchfork_http.c"
+#line 2747 "pitchfork_http.c"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto st83;
@@ -2766,58 +2767,58 @@ case 83:
 		goto st81;
 	goto st0;
 tr103:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st84;
 st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 2779 "pitchfork_http.c"
+#line 2780 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 84: goto tr134;
 		case 116: goto tr134;
 	}
 	goto st0;
 tr134:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st85;
 st85:
 	if ( ++p == pe )
 		goto _test_eof85;
 case 85:
-#line 2793 "pitchfork_http.c"
+#line 2794 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 84: goto tr135;
 		case 116: goto tr135;
 	}
 	goto st0;
 tr135:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st86;
 st86:
 	if ( ++p == pe )
 		goto _test_eof86;
 case 86:
-#line 2807 "pitchfork_http.c"
+#line 2808 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 80: goto tr136;
 		case 112: goto tr136;
 	}
 	goto st0;
 tr136:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st87;
 st87:
 	if ( ++p == pe )
 		goto _test_eof87;
 case 87:
-#line 2821 "pitchfork_http.c"
+#line 2822 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 58: goto tr137;
 		case 83: goto tr138;
@@ -2825,7 +2826,7 @@ case 87:
 	}
 	goto st0;
 tr137:
-#line 327 "pitchfork_http.rl"
+#line 328 "pitchfork_http.rl"
 	{
     rb_hash_aset(hp->env, g_rack_url_scheme, STR_NEW(mark, p));
   }
@@ -2834,7 +2835,7 @@ st88:
 	if ( ++p == pe )
 		goto _test_eof88;
 case 88:
-#line 2838 "pitchfork_http.c"
+#line 2839 "pitchfork_http.c"
 	if ( (*p) == 47 )
 		goto st89;
 	goto st0;
@@ -2922,14 +2923,14 @@ case 93:
 		goto st91;
 	goto st0;
 tr143:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st94;
 st94:
 	if ( ++p == pe )
 		goto _test_eof94;
 case 94:
-#line 2933 "pitchfork_http.c"
+#line 2934 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 37: goto st92;
 		case 47: goto tr147;
@@ -2981,14 +2982,14 @@ case 95:
 		goto st0;
 	goto st91;
 tr144:
-#line 317 "pitchfork_http.rl"
+#line 318 "pitchfork_http.rl"
 	{MARK(mark, p); }
 	goto st96;
 st96:
 	if ( ++p == pe )
 		goto _test_eof96;
 case 96:
-#line 2992 "pitchfork_http.c"
+#line 2993 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 37: goto st92;
 		case 47: goto st0;
@@ -3066,14 +3067,14 @@ case 98:
 		goto st0;
 	goto st91;
 tr138:
-#line 321 "pitchfork_http.rl"
+#line 322 "pitchfork_http.rl"
 	{ downcase_char(deconst(p)); }
 	goto st99;
 st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3077 "pitchfork_http.c"
+#line 3078 "pitchfork_http.c"
 	if ( (*p) == 58 )
 		goto tr137;
 	goto st0;
@@ -3093,7 +3094,7 @@ case 100:
 		goto tr152;
 	goto st0;
 tr151:
-#line 366 "pitchfork_http.rl"
+#line 367 "pitchfork_http.rl"
 	{
     hp->len.chunk = step_incr(hp->len.chunk, (*p), 16);
     if (hp->len.chunk < 0)
@@ -3104,7 +3105,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3108 "pitchfork_http.c"
+#line 3109 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr153;
 		case 13: goto st102;
@@ -3121,7 +3122,7 @@ case 101:
 		goto tr152;
 	goto st0;
 tr153:
-#line 395 "pitchfork_http.rl"
+#line 396 "pitchfork_http.rl"
 	{
     HP_FL_SET(hp, INTRAILER);
     cs = http_parser_en_Trailers;
@@ -3134,7 +3135,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 3138 "pitchfork_http.c"
+#line 3139 "pitchfork_http.c"
 	goto st0;
 st102:
 	if ( ++p == pe )
@@ -3144,7 +3145,7 @@ case 102:
 		goto tr153;
 	goto st0;
 tr152:
-#line 366 "pitchfork_http.rl"
+#line 367 "pitchfork_http.rl"
 	{
     hp->len.chunk = step_incr(hp->len.chunk, (*p), 16);
     if (hp->len.chunk < 0)
@@ -3155,7 +3156,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3159 "pitchfork_http.c"
+#line 3160 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto st104;
 		case 13: goto st107;
@@ -3176,7 +3177,7 @@ st104:
 case 104:
 	goto tr159;
 tr159:
-#line 403 "pitchfork_http.rl"
+#line 404 "pitchfork_http.rl"
 	{
   skip_chunk_data_hack: {
     size_t nr = MIN((size_t)hp->len.chunk, REMAINING);
@@ -3198,7 +3199,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3202 "pitchfork_http.c"
+#line 3203 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto st100;
 		case 13: goto st106;
@@ -3405,30 +3406,30 @@ case 113:
 		goto st113;
 	goto st0;
 tr172:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st114;
 tr175:
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st114;
 tr182:
-#line 323 "pitchfork_http.rl"
-	{ MARK(mark, p); }
 #line 324 "pitchfork_http.rl"
+	{ MARK(mark, p); }
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st114;
 tr185:
-#line 324 "pitchfork_http.rl"
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st114;
 st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-#line 3432 "pitchfork_http.c"
+#line 3433 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto st115;
 		case 10: goto tr167;
@@ -3457,14 +3458,14 @@ case 114:
 		goto tr169;
 	goto st0;
 tr171:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st115;
 st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3468 "pitchfork_http.c"
+#line 3469 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto tr171;
 		case 10: goto tr172;
@@ -3476,14 +3477,14 @@ case 115:
 		goto st0;
 	goto tr170;
 tr170:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st116;
 st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3487 "pitchfork_http.c"
+#line 3488 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr175;
 		case 13: goto tr176;
@@ -3496,35 +3497,35 @@ case 116:
 		goto st0;
 	goto st116;
 tr173:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st117;
 tr176:
-#line 325 "pitchfork_http.rl"
+#line 326 "pitchfork_http.rl"
 	{ write_cont_value(hp, buffer, p); }
 	goto st117;
 tr183:
-#line 323 "pitchfork_http.rl"
-	{ MARK(mark, p); }
 #line 324 "pitchfork_http.rl"
+	{ MARK(mark, p); }
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st117;
 tr186:
-#line 324 "pitchfork_http.rl"
+#line 325 "pitchfork_http.rl"
 	{ write_value(self, hp, buffer, p); }
 	goto st117;
 st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 3523 "pitchfork_http.c"
+#line 3524 "pitchfork_http.c"
 	if ( (*p) == 10 )
 		goto st114;
 	goto st0;
 tr167:
-#line 390 "pitchfork_http.rl"
+#line 391 "pitchfork_http.rl"
 	{
     cs = http_parser_first_final;
     goto post_exec;
@@ -3534,7 +3535,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 3538 "pitchfork_http.c"
+#line 3539 "pitchfork_http.c"
 	goto st0;
 st118:
 	if ( ++p == pe )
@@ -3544,20 +3545,20 @@ case 118:
 		goto tr167;
 	goto st0;
 tr169:
-#line 319 "pitchfork_http.rl"
-	{ MARK(start.field, p); }
 #line 320 "pitchfork_http.rl"
+	{ MARK(start.field, p); }
+#line 321 "pitchfork_http.rl"
 	{ snake_upcase_char(deconst(p)); }
 	goto st119;
 tr178:
-#line 320 "pitchfork_http.rl"
+#line 321 "pitchfork_http.rl"
 	{ snake_upcase_char(deconst(p)); }
 	goto st119;
 st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 3561 "pitchfork_http.c"
+#line 3562 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 33: goto tr178;
 		case 58: goto tr179;
@@ -3583,18 +3584,18 @@ case 119:
 		goto tr178;
 	goto st0;
 tr181:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st120;
 tr179:
-#line 322 "pitchfork_http.rl"
+#line 323 "pitchfork_http.rl"
 	{ hp->s.field_len = LEN(start.field, p); }
 	goto st120;
 st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 3598 "pitchfork_http.c"
+#line 3599 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 9: goto tr181;
 		case 10: goto tr182;
@@ -3606,14 +3607,14 @@ case 120:
 		goto st0;
 	goto tr180;
 tr180:
-#line 323 "pitchfork_http.rl"
+#line 324 "pitchfork_http.rl"
 	{ MARK(mark, p); }
 	goto st121;
 st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 3617 "pitchfork_http.c"
+#line 3618 "pitchfork_http.c"
 	switch( (*p) ) {
 		case 10: goto tr185;
 		case 13: goto tr186;
@@ -3754,7 +3755,7 @@ case 121:
 	_out: {}
 	}
 
-#line 464 "pitchfork_http.rl"
+#line 465 "pitchfork_http.rl"
 post_exec: /* "_out:" also goes here */
   if (hp->cs != http_parser_error)
     hp->cs = cs;
@@ -4318,5 +4319,6 @@ RUBY_FUNC_EXPORTED void Init_pitchfork_http(void)
 
   init_epollexclusive(mPitchfork);
   init_child_subreaper(mPitchfork);
+  init_pitchfork_memory_page(mPitchfork);
 }
 #undef SET_GLOBAL

--- a/ext/pitchfork_http/pitchfork_http.c
+++ b/ext/pitchfork_http/pitchfork_http.c
@@ -4254,7 +4254,7 @@ static VALUE HttpParser_rssget(VALUE self)
   assert(!NIL_P(var) && "missed global field"); \
 } while (0)
 
-void Init_pitchfork_http(void)
+RUBY_FUNC_EXPORTED void Init_pitchfork_http(void)
 {
   VALUE mPitchfork;
 

--- a/ext/pitchfork_http/pitchfork_http.rl
+++ b/ext/pitchfork_http/pitchfork_http.rl
@@ -16,6 +16,7 @@
 #include "child_subreaper.h"
 
 void init_pitchfork_httpdate(void);
+void init_pitchfork_memory_page(VALUE);
 
 #define UH_FL_CHUNKED  0x1
 #define UH_FL_HASBODY  0x2
@@ -1024,5 +1025,6 @@ RUBY_FUNC_EXPORTED void Init_pitchfork_http(void)
 
   init_epollexclusive(mPitchfork);
   init_child_subreaper(mPitchfork);
+  init_pitchfork_memory_page(mPitchfork);
 }
 #undef SET_GLOBAL

--- a/ext/pitchfork_http/pitchfork_http.rl
+++ b/ext/pitchfork_http/pitchfork_http.rl
@@ -960,7 +960,7 @@ static VALUE HttpParser_rssget(VALUE self)
   assert(!NIL_P(var) && "missed global field"); \
 } while (0)
 
-void Init_pitchfork_http(void)
+RUBY_FUNC_EXPORTED void Init_pitchfork_http(void)
 {
   VALUE mPitchfork;
 

--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 require 'etc'
 require 'stringio'
-require 'raindrops'
 require 'io/wait'
 
 begin

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -147,7 +147,7 @@ module Pitchfork
         :QUIT, :INT, :TERM, :USR2, :TTIN, :TTOU ]
 
       Info.workers_count = worker_processes
-      SharedMemory.preallocate_drops(worker_processes)
+      SharedMemory.preallocate_pages(worker_processes)
     end
 
     # Runs the thing.  Returns self so you can run join on it

--- a/pitchfork.gemspec
+++ b/pitchfork.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5.0"
 
-  s.add_dependency(%q<raindrops>, '~> 0.7')
   s.add_dependency(%q<rack>, '>= 2.0')
 
   # Note: To avoid ambiguity, we intentionally avoid the SPDX-compatible

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,8 +40,8 @@ end
 module Pitchfork
   class Test < Minitest::Test
     def before_setup
-      Pitchfork::SharedMemory::DROPS.clear
-      Pitchfork::SharedMemory.preallocate_drops(4)
+      Pitchfork::SharedMemory::PAGES.clear
+      Pitchfork::SharedMemory.preallocate_pages(4)
     end
 
     private

--- a/test/unit/test_worker.rb
+++ b/test/unit/test_worker.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 class TestWorker < Pitchfork::Test
   def test_create_many_workers
-    Pitchfork::SharedMemory.preallocate_drops(1024)
+    Pitchfork::SharedMemory.preallocate_pages(1024)
 
     now = Time.now.to_i
     (0...1024).each do |i|


### PR DESCRIPTION
We're only using a small part of it, so it's much better to inline that functionality.

Raindrops is licensed under LGPL v2.1+, and Pitchfork under GPL 2+.
According to [https://www.gnu.org/licenses/gpl-faq.](https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility) it's authorized to redistribute it under GPL.