### PR TITLE
Declare dependency on `logger`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     pitchfork (0.14.0)
+      logger
       rack (>= 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    logger (1.6.0)
     minitest (5.22.2)
     nio4r (2.7.0)
     puma (6.4.2)

--- a/pitchfork.gemspec
+++ b/pitchfork.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5.0"
 
-  s.add_dependency(%q<rack>, '>= 2.0')
+  s.add_dependency('rack', '>= 2.0')
+  s.add_dependency('logger')
 
   # Note: To avoid ambiguity, we intentionally avoid the SPDX-compatible
   # 'Ruby' here since Ruby 1.9.3 switched to BSD-2-Clause, but we


### PR DESCRIPTION
It will be promoted to a bundled gem in Ruby 3.5:
https://bugs.ruby-lang.org/issues/20309

Fix: https://github.com/Shopify/pitchfork/issues/125