### PR TITLE
Improve detection for streaming requests

### DIFF
--- a/lib/pitchfork/chunked.rb
+++ b/lib/pitchfork/chunked.rb
@@ -106,7 +106,7 @@ module Pitchfork
 
       if !env.key?('rack.hijack_io') && # full highjack
          !headers['rack.hijack'] && # partial hijack
-         !body.respond_to?(:call) && # streaming body
+         body.respond_to?(:each) && # body must be enumerable (i.e. non-streaming)
           chunkable_version?(env[Rack::SERVER_PROTOCOL]) &&
          !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[Rack::CONTENT_LENGTH] &&

--- a/test/integration/test_http_basic.rb
+++ b/test/integration/test_http_basic.rb
@@ -51,10 +51,6 @@ class HttpBasicTest < Pitchfork::IntegrationTest
   def test_chunked_encoding
     addr, port = unused_port
 
-    if Rack::RELEASE < "3"
-      skip("Rack::Lint wraps the response body and responds to :call which prevents chunked encoding")
-    end
-
     pid = spawn_server(app: File.join(ROOT, "test/integration/apps/chunked.ru"), config: <<~CONFIG)
       listen "#{addr}:#{port}"
       worker_processes 1


### PR DESCRIPTION
As per https://github.com/Shopify/pitchfork/pull/132#discussion_r1639717903

The `Rack::Lint` middleware responds to both `each` and `call`. I assumed this was a limitation similar to the other two skips where its not possible to have it lint on both versions but that assumption was wrong.