### PR TITLE
Don't advertise support for non-working connection upgrade.

### DIFF
--- a/lib/pitchfork/http_parser.rb
+++ b/lib/pitchfork/http_parser.rb
@@ -93,6 +93,9 @@ module Pitchfork
       e['pitchfork.socket'] = socket
       e['rack.hijack'] = self
 
+      # We don't support connection upgrade:
+      e.delete('HTTP_UPGRADE')
+
       e.merge!(DEFAULTS)
     end
 

--- a/test/integration/upgrade.ru
+++ b/test/integration/upgrade.ru
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+run lambda { |env|
+  if env['HTTP_UPGRADE']
+    [404, {}, ["Upgrade not supported"]]
+  else
+    [200, {}, ["Normal response"]]
+  end
+}


### PR DESCRIPTION
As discussed here: https://github.com/socketry/rack-conform/pull/24