### PR TITLE
Use `exit!` for exiting the middle process when forking a new worker or mold.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Use `exit!` for exiting the middle process when forking a new worker or mold. 
+  This skips `at_exit` and finalizer hooks, which shouldn't be needed.
+
 # 0.15.0
 
 - Encode pure ASCII strings in Rack env as UTF-8, as allowed by the rack spec.


### PR DESCRIPTION
This skips `at_exit` and finalizer hooks, which shouldn't be needed.

There is little point wasting time running all of these, all these hooks will be ran when both the parent and the child exit, I can see no use case for wasting time and risking deadlock here.