### PR TITLE
Use Ubuntu 22.04 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       RACK_VERSION: "${{ matrix.rack }}"
       RUBYOPT: "${{ matrix.rubyopt }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
#148 fails but it's not the code's fault, GitHub switched to Ubuntu 24.04 for `ubuntu-latest`. This just restores the way it was while we fix #149.