### PR TITLE
Consistent logging

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -325,7 +325,7 @@ spawning the original workers.
 
 ```ruby
 after_monitor_ready do |server|
-  server.logger.info("Monitor pid=#{Process.pid} ready")
+  server.logger.info("monitor pid=#{Process.pid} ready")
 end
 ```
 

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -41,21 +41,17 @@ module Pitchfork
       :worker_processes => 1,
       :before_fork => nil,
       :after_worker_fork => lambda { |server, worker|
-        server.logger.info("worker=#{worker.nr} gen=#{worker.generation} pid=#{$$} spawned")
+        server.logger.info("#{worker.to_log} spawned")
       },
       :after_mold_fork => lambda { |server, worker|
-        server.logger.info("mold gen=#{worker.generation} pid=#{$$} spawned")
+        server.logger.info("#{worker.to_log} spawned")
       },
       :before_worker_exit => nil,
       :after_worker_exit => lambda { |server, worker, status|
         m = if worker.nil?
           "reaped unknown process (#{status.inspect})"
-        elsif worker.mold?
-          "mold gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
-        elsif worker.service?
-          "service gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
         else
-          "worker=#{worker.nr rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
+          "#{worker.to_log} reaped (#{status.inspect})"
         end
         if status.success?
           server.logger.info(m)
@@ -64,7 +60,7 @@ module Pitchfork
         end
       },
       :after_worker_ready => lambda { |server, worker|
-        server.logger.info("worker=#{worker.nr} gen=#{worker.generation} ready")
+        server.logger.info("#{worker.to_log} ready")
       },
       :after_monitor_ready => lambda { |server|
         server.logger.info("monitor pid=#{Process.pid} ready")

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -49,13 +49,13 @@ module Pitchfork
       :before_worker_exit => nil,
       :after_worker_exit => lambda { |server, worker, status|
         m = if worker.nil?
-          "repead unknown process (#{status.inspect})"
+          "reaped unknown process (#{status.inspect})"
         elsif worker.mold?
-          "mold pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
+          "mold gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
         elsif worker.service?
-          "service pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
+          "service gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
         else
-          "worker=#{worker.nr rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} reaped (#{status.inspect})"
+          "worker=#{worker.nr rescue 'unknown'} gen=#{worker.generation rescue 'unknown'} pid=#{worker.pid rescue 'unknown'} reaped (#{status.inspect})"
         end
         if status.success?
           server.logger.info(m)
@@ -67,7 +67,7 @@ module Pitchfork
         server.logger.info("worker=#{worker.nr} gen=#{worker.generation} ready")
       },
       :after_monitor_ready => lambda { |server|
-        server.logger.info("Monitor pid=#{Process.pid} ready")
+        server.logger.info("monitor pid=#{Process.pid} ready")
       },
       :after_worker_timeout => nil,
       :after_worker_hard_timeout => nil,

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -50,7 +50,7 @@ module Pitchfork
 
       def call(original_thread) # :nodoc:
         begin
-          @server.logger.error("worker=#{@worker.nr} pid=#{@worker.pid} timed out, exiting")
+          @server.logger.error("#{@worker.to_log} timed out, exiting")
           if @callback
             @callback.call(@server, @worker, Info.new(original_thread, @rack_env))
           end
@@ -363,19 +363,19 @@ module Pitchfork
       when Message::WorkerSpawned
         worker = @children.update(message)
         # TODO: should we send a message to the worker to acknowledge?
-        logger.info "worker=#{worker.nr} gen=#{worker.generation} pid=#{worker.pid} registered"
+        logger.info "#{worker.to_log} registered"
       when Message::MoldSpawned
         new_mold = @children.update(message)
-        logger.info("mold gen=#{new_mold.generation} pid=#{new_mold.pid} spawned")
+        logger.info("#{new_mold.to_log} spawned")
       when Message::ServiceSpawned
         new_service = @children.update(message)
-        logger.info("service gen=#{new_service.generation} pid=#{new_service.pid} spawned")
+        logger.info("#{new_service.to_log} spawned")
       when Message::MoldReady
         old_molds = @children.molds
         new_mold = @children.update(message)
-        logger.info("mold gen=#{new_mold.generation} pid=#{new_mold.pid} ready")
+        logger.info("#{new_mold.to_log} ready")
         old_molds.each do |old_mold|
-          logger.info("Terminating old mold gen=#{old_mold.generation} pid=#{old_mold.pid}")
+          logger.info("Terminating old #{old_mold.to_log}")
           old_mold.soft_kill(:TERM)
         end
       else
@@ -413,7 +413,7 @@ module Pitchfork
     end
 
     def worker_exit(worker)
-      logger.info "worker=#{worker.nr} gen=#{worker.generation} pid=#{worker.pid} exiting"
+      logger.info "#{worker.to_log} exiting"
       proc_name status: "exiting"
 
       if @before_worker_exit
@@ -427,7 +427,7 @@ module Pitchfork
     end
 
     def service_exit(service)
-      logger.info "service gen=#{service.generation} pid=#{service.pid} exiting"
+      logger.info "#{service.to_log} exiting"
       proc_name status: "exiting"
 
       if @before_service_worker_exit
@@ -548,11 +548,7 @@ module Pitchfork
         end
       end
 
-      if child.mold?
-        logger.error "mold gen=#{child.generation} pid=#{child.pid} timed out, killing"
-      else
-        logger.error "worker=#{child.nr} gen=#{child.generation} pid=#{child.pid} timed out, killing"
-      end
+      logger.error "#{child.to_log} timed out, killing"
       @children.hard_kill(@timeout_signal.call(child.pid), child) # take no prisoners for hard timeout violations
     end
 
@@ -583,7 +579,7 @@ module Pitchfork
     end
 
     def spawn_worker(worker, detach:)
-      logger.info("worker=#{worker.nr} gen=#{worker.generation} spawning...")
+      logger.info("#{worker.to_log} spawning...")
 
       # We set the deadline before spawning the child so that if for some
       # reason it gets stuck before reaching the worker loop,
@@ -646,7 +642,7 @@ module Pitchfork
     end
 
     def spawn_service(service, detach:)
-      logger.info("service gen=#{service.generation} spawning...")
+      logger.info("#{service.to_log} spawning...")
 
       # We set the deadline before spawning the child so that if for some
       # reason it gets stuck before reaching the worker loop,
@@ -759,9 +755,9 @@ module Pitchfork
       if service = @children.service
         if service.outdated?
           if service.soft_kill(:TERM)
-            logger.info("Sent SIGTERM to service gen=#{service.generation} pid=#{service.pid}")
+            logger.info("Sent SIGTERM to #{service.to_log}")
           else
-            logger.info("Failed to send SIGTERM to service gen=#{service.generation} pid=#{service.pid}")
+            logger.info("Failed to send SIGTERM to #{service.to_log}")
           end
         end
       end
@@ -770,10 +766,10 @@ module Pitchfork
         outdated_workers = @children.workers.select { |w| !w.exiting? && w.generation < @children.mold.generation }
         outdated_workers.each do |worker|
           if worker.soft_kill(:TERM)
-            logger.info("Sent SIGTERM to worker=#{worker.nr} gen=#{worker.generation} pid=#{worker.pid}")
+            logger.info("Sent SIGTERM to #{worker.to_log}")
             workers_to_restart -= 1
           else
-            logger.info("Failed to send SIGTERM to worker=#{worker.nr} gen=#{worker.generation} pid=#{worker.pid}")
+            logger.info("Failed to send SIGTERM to #{worker.to_log}")
           end
           break if workers_to_restart <= 0
         end
@@ -985,7 +981,7 @@ module Pitchfork
               if Info.fork_safe?
                 spawn_mold(worker)
               else
-                logger.error("worker=#{worker.nr} gen=#{worker.generation} is no longer fork safe, can't refork")
+                logger.error("#{worker.to_log} is no longer fork safe, can't refork")
               end
             when Message
               worker.update(client)
@@ -1005,7 +1001,7 @@ module Pitchfork
             if @refork_condition.met?(worker, logger)
               proc_name status: "requests: #{worker.requests_count}, spawning mold"
               if spawn_mold(worker)
-                logger.info("worker=#{worker.nr} gen=#{worker.generation} refork condition met, promoting ourselves")
+                logger.info("#{worker.to_log} refork condition met, promoting ourselves")
               end
               @refork_condition.backoff!
             end
@@ -1068,11 +1064,11 @@ module Pitchfork
                 spawn_worker(Worker.new(message.nr, generation: mold.generation), detach: true)
               rescue ForkFailure
                 if retries > 0
-                  @logger.fatal("mold gen=#{mold.generation} pid=#{mold.pid} failed to spawn a worker, retrying")
+                  @logger.fatal("#{mold.to_log} failed to spawn a worker, retrying")
                   retries -= 1
                   retry
                 else
-                  @logger.fatal("mold gen=#{mold.generation} pid=#{mold.pid} failed to spawn a worker twice in a row - corrupted mold process?")
+                  @logger.fatal("#{mold.to_log} failed to spawn a worker twice in a row - corrupted mold process?")
                   Process.exit(1)
                 end
               rescue => error
@@ -1084,11 +1080,11 @@ module Pitchfork
                 spawn_service(Service.new(generation: mold.generation), detach: true)
               rescue ForkFailure
                 if retries > 0
-                  @logger.fatal("mold gen=#{mold.generation} pid=#{mold.pid} failed to spawn a service, retrying")
+                  @logger.fatal("#{mold.to_log} failed to spawn a service, retrying")
                   retries -= 1
                   retry
                 else
-                  @logger.fatal("mold gen=#{mold.generation} pid=#{mold.pid} failed to spawn a service twice in a row - corrupted mold process?")
+                  @logger.fatal("#{mold.to_log} failed to spawn a service twice in a row - corrupted mold process?")
                   Process.exit(1)
                 end
               rescue => error

--- a/lib/pitchfork/refork_condition.rb
+++ b/lib/pitchfork/refork_condition.rb
@@ -19,7 +19,7 @@ module Pitchfork
           if worker.requests_count >= limit
             return false if backoff?
 
-            logger.info("worker=#{worker.nr} pid=#{worker.pid} processed #{worker.requests_count} requests, triggering a refork")
+            logger.info("#{worker.to_log} processed #{worker.requests_count} requests, triggering a refork")
             return true
           end
         end

--- a/lib/pitchfork/worker.rb
+++ b/lib/pitchfork/worker.rb
@@ -208,6 +208,14 @@ module Pitchfork
       @master&.close
     end
 
+    def to_log
+      if mold?
+        pid ? "mold gen=#{generation} pid=#{pid}" : "mold gen=#{generation}"
+      else
+        pid ? "worker=#{nr} gen=#{generation} pid=#{pid}" : "worker=#{nr} gen=#{generation}"
+      end
+    end
+
     private
 
     def init_deadline
@@ -255,6 +263,10 @@ module Pitchfork
       message = Message::ServiceSpawned.new(@pid, generation, @master)
       control_socket.sendmsg(message)
       @master.close
+    end
+
+    def to_log
+      pid ? "service gen=#{generation} pid=#{pid}" : "service gen=#{generation}"
     end
 
     private

--- a/test/integration/test_boot.rb
+++ b/test/integration/test_boot.rb
@@ -104,7 +104,7 @@ class TestBoot < Pitchfork::IntegrationTest
 
     assert_healthy("http://#{addr}:#{port}")
 
-    assert_stderr("worker=0 gen=0 ready")
+    assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
     assert_stderr(/worker=1 gen=0 pid=\d+ registered/)
     assert_stderr(/worker=1 gen=0 pid=\d+ timed out, killing/, timeout: 4)
 
@@ -126,8 +126,8 @@ class TestBoot < Pitchfork::IntegrationTest
     RUBY
 
     assert_healthy("http://#{addr}:#{port}")
-    assert_stderr("worker=0 gen=0 ready")
-    assert_stderr("worker=1 gen=0 ready")
+    assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+    assert_stderr(/worker=1 gen=0 pid=\d+ ready/)
 
     Process.kill(:KILL, pid)
     Process.waitpid(pid)

--- a/test/integration/test_boot.rb
+++ b/test/integration/test_boot.rb
@@ -105,8 +105,8 @@ class TestBoot < Pitchfork::IntegrationTest
     assert_healthy("http://#{addr}:#{port}")
 
     assert_stderr("worker=0 gen=0 ready")
-    assert_stderr(/worker=1 pid=(\d+) gen=0 registered/)
-    assert_stderr(/worker=1 pid=\d+ gen=0 timed out, killing/, timeout: 4)
+    assert_stderr(/worker=1 gen=0 pid=\d+ registered/)
+    assert_stderr(/worker=1 gen=0 pid=\d+ timed out, killing/, timeout: 4)
 
     assert_clean_shutdown(pid)
   end
@@ -132,8 +132,8 @@ class TestBoot < Pitchfork::IntegrationTest
     Process.kill(:KILL, pid)
     Process.waitpid(pid)
 
-    assert_stderr(/worker=0 pid=(\d+) gen=0 exiting/, timeout: 5)
-    assert_stderr(/worker=1 pid=(\d+) gen=0 exiting/)
+    assert_stderr(/worker=0 gen=0 pid=(\d+) exiting/, timeout: 5)
+    assert_stderr(/worker=1 gen=0 pid=(\d+) exiting/)
 
     assert_raises Errno::ESRCH, Errno::ECHILD do
       25.times do

--- a/test/integration/test_info.rb
+++ b/test/integration/test_info.rb
@@ -11,7 +11,7 @@ class InfoTest < Pitchfork::IntegrationTest
     CONFIG
 
     assert_healthy("http://#{addr}:#{port}")
-    assert_stderr "worker=3 gen=0 ready"
+    assert_stderr(/worker=3 gen=0 pid=\d+ ready/)
 
     response = http_get("http://#{addr}:#{port}/")
     assert_equal({workers_count: 4, live_workers_count: 4}.inspect, response.body)

--- a/test/integration/test_info.rb
+++ b/test/integration/test_info.rb
@@ -17,9 +17,9 @@ class InfoTest < Pitchfork::IntegrationTest
     assert_equal({workers_count: 4, live_workers_count: 4}.inspect, response.body)
 
     Process.kill(:TTOU, pid)
-    assert_stderr(/worker=3 pid=\d+ gen=0 reaped/)
+    assert_stderr(/worker=3 gen=0 pid=\d+ reaped/)
     Process.kill(:TTOU, pid)
-    assert_stderr(/worker=2 pid=\d+ gen=0 reaped/)
+    assert_stderr(/worker=2 gen=0 pid=\d+ reaped/)
 
     response = http_get("http://#{addr}:#{port}/")
     assert_equal({workers_count: 4, live_workers_count: 2}.inspect, response.body)

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -20,8 +20,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "Refork condition met, promoting ourselves", timeout: 3
-      assert_stderr "Terminating old mold pid="
+      assert_stderr "refork condition met, promoting ourselves", timeout: 3
+      assert_stderr "Terminating old mold gen=0 pid="
       assert_stderr "worker=0 gen=1 ready"
       assert_stderr "worker=1 gen=1 ready"
 
@@ -57,8 +57,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "Refork condition met, promoting ourselves", timeout: 3
-      assert_stderr(/mold pid=\d+ gen=1 reaped/)
+      assert_stderr "refork condition met, promoting ourselves", timeout: 3
+      assert_stderr(/mold gen=1 pid=\d+ reaped/)
 
       assert_equal true, healthy?("http://#{addr}:#{port}")
 
@@ -93,10 +93,10 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "Refork condition met, promoting ourselves", timeout: 3
+      assert_stderr "refork condition met, promoting ourselves", timeout: 3
 
-      assert_stderr "Failed to spawn a worker. Retrying."
-      assert_stderr "Failed to spawn a worker twice in a row. Corrupted mold process?"
+      assert_stderr "failed to spawn a worker, retrying"
+      assert_stderr "failed to spawn a worker twice in a row - corrupted mold process?"
       assert_stderr "No mold alive, shutting down"
 
       assert_exited(pid, 1, timeout: 5)
@@ -133,9 +133,9 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr(/mold pid=\d+ gen=1 spawned/)
+      assert_stderr(/mold gen=1 pid=\d+ spawned/)
       assert_stderr("[mold crashing]")
-      assert_stderr(/mold pid=\d+ gen=1 reaped/)
+      assert_stderr(/mold gen=1 pid=\d+ reaped/)
 
       10.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -178,9 +178,9 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr(/mold pid=\d+ gen=1 spawned/)
+      assert_stderr(/mold gen=1 pid=\d+ spawned/)
       assert_stderr("[mold locking-up]")
-      assert_stderr(/mold pid=\d+ gen=1 reaped/, timeout: 10)
+      assert_stderr(/mold gen=1 pid=\d+ reaped/, timeout: 10)
 
       10.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -209,7 +209,7 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      refute_match("Refork condition met, promoting ourselves", read_stderr)
+      refute_match("refork condition met, promoting ourselves", read_stderr)
 
       assert_clean_shutdown(pid)
     end
@@ -228,7 +228,7 @@ class ReforkingTest < Pitchfork::IntegrationTest
 
       Process.kill(:USR2, pid)
 
-      assert_stderr "Terminating old mold pid="
+      assert_stderr "Terminating old mold gen=0 pid="
       assert_stderr "worker=0 gen=1 ready"
       assert_stderr "worker=1 gen=1 ready"
 

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -13,8 +13,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/)
 
       9.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -22,8 +22,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
 
       assert_stderr "refork condition met, promoting ourselves", timeout: 3
       assert_stderr "Terminating old mold gen=0 pid="
-      assert_stderr "worker=0 gen=1 ready"
-      assert_stderr "worker=1 gen=1 ready"
+      assert_stderr(/worker=0 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
 
       File.truncate("stderr.log", 0)
 
@@ -31,8 +31,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "worker=0 gen=2 ready", timeout: 3
-      assert_stderr "worker=1 gen=2 ready"
+      assert_stderr(/worker=0 gen=2 pid=\d+ ready/, timeout: 3)
+      assert_stderr(/worker=1 gen=2 pid=\d+ ready/)
 
       assert_clean_shutdown(pid)
     end
@@ -50,8 +50,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/)
 
       9.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -86,8 +86,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready", timeout: 5
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/, timeout: 5)
 
       9.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -126,8 +126,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready", timeout: 5
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/, timeout: 5)
 
       7.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -141,8 +141,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "worker=0 gen=1 ready", timeout: 15
-      assert_stderr "worker=1 gen=1 ready"
+      assert_stderr(/worker=0 gen=1 pid=\d+ ready/, timeout: 15)
+      assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
 
       assert_clean_shutdown(pid)
     end
@@ -171,8 +171,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready", timeout: 5
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/, timeout: 5)
 
       7.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -186,8 +186,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
         assert_equal true, healthy?("http://#{addr}:#{port}")
       end
 
-      assert_stderr "worker=0 gen=1 ready", timeout: 5
-      assert_stderr "worker=1 gen=1 ready"
+      assert_stderr(/worker=0 gen=1 pid=\d+ ready/, timeout: 5)
+      assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
 
       assert_clean_shutdown(pid)
     end
@@ -202,8 +202,8 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/)
 
       20.times do
         assert_equal true, healthy?("http://#{addr}:#{port}")
@@ -223,14 +223,14 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=1 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=0 pid=\d+ ready/)
 
       Process.kill(:USR2, pid)
 
       assert_stderr "Terminating old mold gen=0 pid="
-      assert_stderr "worker=0 gen=1 ready"
-      assert_stderr "worker=1 gen=1 ready"
+      assert_stderr(/worker=0 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
 
       assert_healthy("http://#{addr}:#{port}")
       assert_clean_shutdown(pid)
@@ -251,7 +251,7 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
 
       Process.kill(:USR2, pid)
 
@@ -275,16 +275,16 @@ class ReforkingTest < Pitchfork::IntegrationTest
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
-      assert_stderr "worker=0 gen=0 ready"
-      assert_stderr "worker=4 gen=0 ready"
+      assert_stderr(/worker=0 gen=0 pid=\d+ ready/)
+      assert_stderr(/worker=4 gen=0 pid=\d+ ready/)
 
       Process.kill(:USR2, pid)
 
-      assert_stderr "worker=0 gen=1 ready"
-      assert_stderr "worker=1 gen=1 ready"
-      assert_stderr "worker=2 gen=1 ready"
-      assert_stderr "worker=3 gen=1 ready"
-      assert_stderr "worker=4 gen=1 ready"
+      assert_stderr(/worker=0 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=2 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=3 gen=1 pid=\d+ ready/)
+      assert_stderr(/worker=4 gen=1 pid=\d+ ready/)
 
       assert_clean_shutdown(pid)
 


### PR DESCRIPTION
Consistently log worker `nr` (where relevant) first, then `generation`, then `pid`. Use lowercase letters in most such messages.

Fixes #153
