### PR TITLE
Updates after added/removed/split callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `setpgid` configuration option. When `false`, child processes are not reassigned to their own process group.
   Necessary for initiating a debugging session in a child process (#148).
 - Assume config file is located at `config/pitchfork.rb` if `-c` argument isn't provided.
+- Remove `Pitchfork::Configurator#after_load` and `Pitchfork::Configurator#after_load=`, which have had no function since v0.1.0.
 
 # 0.16.0
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -437,8 +437,18 @@ end
 
 Once the callback complete, the worker will be signaled with `SIGKILL`.
 
-This callback being called in an indication that something is preventing the
+This callback being called is an indication that something is preventing the
 soft timeout from working.
+
+### `before_worker_exit`
+
+Called in the worker process before it is shut down.
+
+```ruby
+before_worker_exit do |server, worker|
+  server.logger.info("worker=#{worker.nr} shuts down after #{worker.requests_count} requests")
+end
+```
 
 ### `after_worker_exit`
 

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -14,7 +14,7 @@ module Pitchfork
     include Pitchfork
 
     # :stopdoc:
-    attr_accessor :set, :config_file, :after_load
+    attr_accessor :set, :config_file
 
     # used to stash stuff for deferred processing of cli options in
     # config.ru.  Do not rely on

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -896,7 +896,7 @@ module Pitchfork
 
     # gets rid of stuff the worker has no business keeping track of
     # to free some resources and drops all sig handlers.
-    # traps for USR2, and HUP may be set in the after_fork Proc
+    # traps for USR2, and HUP may be set in the after_worker_fork/after_mold_fork Procs
     # by the user.
     def init_worker_process(worker)
       proc_name role: "(gen:#{worker.generation}) worker[#{worker.nr}]", status: "init"


### PR DESCRIPTION
- Add documentation for the `before_worker_exit` hook (added in 0efdfcff2e398277a69987b9ab2c75ed395ac6c4).
- Remove accessor for `after_load` (removed in 9f3020ab9dd61751ad41b49f0fc3dfa85b0f277b). May cause NoMethodError, so mentioned in the changelog.
- Update code comment mentioning `after_fork` (split in 596a458a6ba2c3ae9a82fb75e0e871853d08b636).
