### PR TITLE
Change some words: master→monitor and unicorn→pitchfork

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5,7 +5,7 @@
   and fix.
 
 * Resiliency: If something goes catastrophically wrong and your application
-  is dead locked or somehow stuck, once the request timeout is reached the master
+  is dead locked or somehow stuck, once the request timeout is reached the monitor
   process will take care of sending `kill -9` to the affected worker and
   spawn a new one to replace it.
 
@@ -32,7 +32,7 @@
   optional, separate config_file may be used to modify supported
   configuration changes.
 
-* One master process spawns and reaps worker processes.
+* One monitor process spawns and reaps worker processes.
 
 * The number of worker processes should be scaled to the number of
   CPUs or memory you have. If you have an existing
@@ -75,12 +75,12 @@
   unportable event notification solutions for watching few
   file descriptors.
 
-* If the master process dies unexpectedly for any reason,
+* If the monitor process dies unexpectedly for any reason,
   workers will notice within :timeout/2 seconds and follow
-  the master to its death.
+  the monitor to its death.
 
 * There is never any explicit real-time dependency or communication
-  between the worker processes nor to the master process.
+  between the worker processes nor to the monitor process.
   Synchronization is handled entirely by the OS kernel and shared
   resources are never accessed by the worker when it is servicing
   a client.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -34,7 +34,7 @@ the right tool with the right configuration for the right job.
 
 ## Improved Performance Through Reverse Proxying
 
-By acting as a buffer to shield unicorn from slow I/O, a reverse proxy
+By acting as a buffer to shield `pitchfork` from slow I/O, a reverse proxy
 will inevitably incur overhead in the form of extra data copies.
 However, as I/O within a local network is fast (and faster still
 with local sockets), this overhead is negligible for the vast majority
@@ -45,7 +45,7 @@ A reverse proxy for `pitchfork` should meet the following requirements:
 
 1. It should fully buffer all HTTP requests (and large responses).
    Each request should be "corked" in the reverse proxy and sent
-   as fast as possible to the backend unicorn processes.  This is
+   as fast as possible to the backend `pitchfork` processes.  This is
    the most important feature to look for when choosing a
    reverse proxy for `pitchfork`.
 

--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -1,10 +1,10 @@
 ## Signal handling
 
-In general, signals need to only be sent to the master process. However,
+In general, signals need to only be sent to the monitor process. However,
 the signals Pitchfork uses internally to communicate with the worker
 processes are documented here as well.
 
-### Master Process
+### Monitor Process
 
 * `INT` - quick shutdown, kills all workers immediately
 
@@ -21,18 +21,18 @@ processes are documented here as well.
 
 ### Worker Processes
 
-Note: the master uses a pipe to signal workers
+Note: the monitor uses a pipe to signal workers
 instead of `kill(2)` for most cases.  Using signals still works and
 remains supported for external tools/libraries, however.
 
 Sending signals directly to the worker processes should not normally be
-needed.  If the master process is running, any exited worker will be
+needed.  If the monitor process is running, any exited worker will be
 automatically respawned.
 
 * `INT` - Quick shutdown, immediately exit.
-  The master process will respawn a worker to replace this one.
+  The monitor process will respawn a worker to replace this one.
   Immediate shutdown is still triggered using kill(2) and not the
   internal pipe as of unicorn 4.8
 
 * `QUIT/TERM` - Gracefully exit after finishing the current request.
-  The master process will respawn a worker to replace this one.
+  The monitor process will respawn a worker to replace this one.

--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -31,8 +31,7 @@ automatically respawned.
 
 * `INT` - Quick shutdown, immediately exit.
   The monitor process will respawn a worker to replace this one.
-  Immediate shutdown is still triggered using kill(2) and not the
-  internal pipe as of unicorn 4.8
+  Immediate shutdown is triggered using kill(2).
 
 * `QUIT/TERM` - Gracefully exit after finishing the current request.
   The monitor process will respawn a worker to replace this one.

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -1,6 +1,6 @@
 # Tuning pitchfork
 
-unicorn performance is generally as good as a (mostly) Ruby web server
+Pitchfork performance is generally as good as a (mostly) Ruby web server
 can provide. Most often the performance bottleneck is in the web
 application running on Pitchfork rather than Pitchfork itself.
 
@@ -14,7 +14,7 @@ See Pitchfork::Configurator for details on the config file format.
 * `worker_processes` should be scaled to the number of processes your
   backend system(s) can support. DO NOT scale it to the number of
   external network clients your application expects to be serving.
-  unicorn is NOT for serving slow clients, that is the job of nginx.
+  Pitchfork is NOT for serving slow clients, that is the job of nginx.
 
 * `worker_processes` should be *at* *least* the number of CPU cores on
   a dedicated server (unless you do not have enough memory).

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -71,7 +71,7 @@ http {
   # this can be any application server, not just unicorn
   upstream app_server {
     # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response (in case the unicorn master nukes a
+    # to return a good HTTP response (in case the unicorn monitor nukes a
     # single worker for timing out).
 
     # for UNIX domain socket setups:

--- a/examples/pitchfork.conf.rb
+++ b/examples/pitchfork.conf.rb
@@ -26,7 +26,7 @@ run_once = true
 
 after_mold_fork do |server, mold|
   # Occasionally, it may be necessary to run non-idempotent code in the
-  # master before forking.  Keep in mind the above disconnect! example
+  # monitor before forking.  Keep in mind the above disconnect! example
   # is idempotent and does not need a guard.
   if run_once
     # do_something_once_here ...

--- a/ext/pitchfork_http/c_util.h
+++ b/ext/pitchfork_http/c_util.h
@@ -1,6 +1,6 @@
 /*
  * Generic C functions and macros go here, there are no dependencies
- * on Unicorn internal structures or the Ruby C API in here.
+ * on Pitchfork internal structures or the Ruby C API in here.
  */
 
 #ifndef UH_util_h
@@ -60,7 +60,7 @@ static int hexchar2int(int xdigit)
   if (xdigit >= 'a' && xdigit <= 'f')
     return xdigit - 'a' + 10;
 
-  /* Ragel already does runtime range checking for us in Unicorn: */
+  /* Ragel already does runtime range checking for us in Pitchfork: */
   assert(xdigit >= '0' && xdigit <= '9' && "invalid digit character");
 
   return xdigit - '0';

--- a/ext/pitchfork_http/epollexclusive.h
+++ b/ext/pitchfork_http/epollexclusive.h
@@ -1,11 +1,11 @@
 /*
- * This is only intended for use inside a unicorn worker, nowhere else.
+ * This is only intended for use inside a pitchfork worker, nowhere else.
  * EPOLLEXCLUSIVE somewhat mitigates the thundering herd problem for
  * mostly idle processes since we can't use blocking accept4.
  * This is NOT intended for use with multi-threaded servers, nor
  * single-threaded multi-client ("C10K") servers or anything advanced
  * like that.  This use of epoll is only appropriate for a primitive,
- * single-client, single-threaded servers like unicorn that need to
+ * single-client, single-threaded servers like pitchfork that need to
  * support SIGKILL timeouts and parent death detection.
  */
 #if defined(HAVE_EPOLL_CREATE1)

--- a/lib/pitchfork/children.rb
+++ b/lib/pitchfork/children.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Pitchfork
-  # This class keep tracks of the state of all the master children.
+  # This class keep tracks of the state of all the monitor children.
   class Children
     attr_reader :mold, :service
     attr_accessor :last_generation

--- a/lib/pitchfork/info.rb
+++ b/lib/pitchfork/info.rb
@@ -104,7 +104,7 @@ module Pitchfork
 
       # Returns true if the server is shutting down.
       # This can be useful to implement health check endpoints, so they
-      # can fail immediately after TERM/QUIT/INT was received by the master
+      # can fail immediately after TERM/QUIT/INT was received by the monitor
       # process.
       # Otherwise they may succeed while Pitchfork is draining requests causing
       # more requests to be sent.

--- a/test/integration/README
+++ b/test/integration/README
@@ -1,4 +1,4 @@
-= Unicorn integration test suite
+= Pitchfork integration test suite
 
 These are all integration tests that start the server on random, unused
 TCP ports or Unix domain sockets.  They're all designed to run

--- a/test/integration/test_heartbeat_timeout.rb
+++ b/test/integration/test_heartbeat_timeout.rb
@@ -40,7 +40,7 @@ class HearbeatTimeoutTest < Pitchfork::IntegrationTest
     new_worker_pid = Net::HTTP.get(URI("http://#{addr}:#{port}/"))
     refute_equal worker_pid, new_worker_pid
 
-    # SIGSTOP, wait, then SIGCONT master, worker shouldn't be affected
+    # SIGSTOP, wait, then SIGCONT monitor, worker shouldn't be affected
     Process.kill(:STOP, pid)
     sleep(timeout + 1)
     Process.kill(:CONT, pid)

--- a/test/slow/test_signals.rb
+++ b/test/slow/test_signals.rb
@@ -58,7 +58,7 @@ class SignalsTest < Pitchfork::Test
     sock = tcp_socket('127.0.0.1', @port)
     sock.syswrite("GET / HTTP/1.0\r\n\r\n")
     buf = rd.readpartial(1)
-    wait_master_ready("test_stderr.#{pid}.log")
+    wait_monitor_ready("test_stderr.#{pid}.log")
     Process.kill(:INT, pid)
     Process.waitpid(pid)
     assert_equal '.', buf

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -181,7 +181,7 @@ module Pitchfork
     end
 
     def assert_shutdown(pid)
-      wait_master_ready("test_stderr.#{pid}.log")
+      wait_monitor_ready("test_stderr.#{pid}.log")
       Process.kill(:QUIT, pid)
       pid, status = Process.waitpid2(pid)
       assert status.success?, "exited successfully"
@@ -202,16 +202,16 @@ module Pitchfork
             "\n\t#{lines.join("\n\t")}\n"
     end
 
-    def wait_master_ready(master_log)
+    def wait_monitor_ready(monitor_log)
       tries = DEFAULT_TRIES
       while (tries -= 1) > 0
         begin
-          File.readlines(master_log).grep(/master process ready/)[0] and return
+          File.readlines(monitor_log).grep(/monitor process ready/)[0] and return
         rescue Errno::ENOENT
         end
         sleep DEFAULT_RES
       end
-      raise "master process never became ready"
+      raise "monitor process never became ready"
     end
 
     def wait_for_file(path)


### PR DESCRIPTION
While reading https://byroot.github.io/ruby/performance/2025/03/04/the-pitchfork-story.html, I noticed this sentence:

> Now that I could more significantly change the server, I decided to move the responsibility of spawning new workers out of the master process, which I renamed “monitor process” for the occasion.

I had always been a bit confused by the code and documents using both “master” and “monitor” terms, and honestly thought they meant two different things.

Now, in this PR, the first commit changes docs and comments to always use “monitor”.

The 2nd commit changes (almost) all mentions of “Unicorn” into “Pitchfork” – but of course not when mentioning Pitchfork’s history, etc.

~There’s still some mentions of “master”, e.g. `HttpServer#master_sleep`, `HttpServer#awaken_master`, `Worker#register_to_master`, and a `@master_pid` ivar. I’m happy to change these too, if they are not deemed breaking changes. (The `HttpServer` methods are private, so they _should_ be safe to change).~ Added into the first commit.