### PR TITLE
Fix default for `setpgid`

### DIFF
--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -75,7 +75,7 @@ module Pitchfork
       :client_body_buffer_size => Pitchfork::Const::MAX_BODY,
       :before_service_worker_ready => nil,
       :before_service_worker_exit => nil,
-      :setpgid => false,
+      :setpgid => true,
     }
     #:startdoc:
 

--- a/test/integration/test_configuration.rb
+++ b/test/integration/test_configuration.rb
@@ -189,6 +189,25 @@ class ConfigurationTest < Pitchfork::IntegrationTest
     assert_clean_shutdown(pid)
   end
 
+  def test_setpgid_default
+    addr, port = unused_port
+
+    pid = spawn_server(app: File.join(ROOT, "test/integration/pid.ru"), config: <<~CONFIG)
+      listen "#{addr}:#{port}"
+      worker_processes 1
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+
+    worker_pid = Net::HTTP.get(URI("http://#{addr}:#{port}")).strip.to_i
+
+    pgid_pid = Process.getpgid(pid)
+    pgid_worker = Process.getpgid(worker_pid)
+
+    refute_equal(pgid_pid, pgid_worker)
+    assert_clean_shutdown(pid)
+  end
+
   def test_setpgid_true
     addr, port = unused_port
 


### PR DESCRIPTION
In #148 I added `setpgid` as a configuration option and noted that the [default value is
true](https://github.com/Shopify/pitchfork/pull/148/files#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409R181) when I [actually set it to
false](https://github.com/Shopify/pitchfork/pull/148/files#diff-c548fe87144e0b662fbdfa224a8e2fc458da80bb2bc04bdcddcff77d6afc5cfcR82).

That's partially due to the fact that I [didn't change the default kwarg value of setpgid in
clean_fork](https://github.com/Shopify/pitchfork/blob/a68238217379fb283561f812b66fc06c8cdd8697/lib/pitchfork.rb#L139). That said, we are now explicitly passing the configuration value of `setpgid` to `clean_fork` so the default value of the kwarg is unused unless someone is calling it manually. Perhaps it would make sense to remove the default so that if someone is calling `clean_fork` manually then they have to be explicit about the behavior that they want. I don't know who would be doing that though.