### PR TITLE
Make the rollout cadence configurable

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -542,6 +542,21 @@ By default automatic reforking isn't enabled.
 
 Make sure to read the [fork safety guide](FORK_SAFETY.md) before enabling reforking.
 
+### `refork_max_unavailable`
+
+```ruby
+refork_max_unavailable 5
+```
+
+Sets the number of workers than can be restarted at a given time.
+
+When a new generation is created, workers from the old generation are rolled out progressively
+and replaced by fresh workers from the new generation.
+
+For instance `refork_max_unavailable 5` means 5 workers may be unavailable during the rollout phase.
+
+The default is `(workers_processes * 0.1).ceil`, or `10%` rounded up.
+
 ## Rack Features
 
 ### `early_hints`

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -216,6 +216,10 @@ module Pitchfork
       set_int(:worker_processes, nr, 1)
     end
 
+    def refork_max_unavailable(max)
+      set_int(:refork_max_unavailable, max, 1)
+    end
+
     def early_hints(bool)
       set_bool(:early_hints, bool)
     end

--- a/test/integration/test_configuration.rb
+++ b/test/integration/test_configuration.rb
@@ -41,6 +41,7 @@ class ConfigurationTest < Pitchfork::IntegrationTest
     assert_stderr("[before_fork]")
     assert_clean_shutdown(pid)
   end
+
   def test_before_worker_exit
     addr, port = unused_port
 

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -10,6 +10,7 @@ class ReforkingTest < Pitchfork::IntegrationTest
         listen "#{addr}:#{port}"
         worker_processes 2
         refork_after [5, 5]
+        refork_max_unavailable 1
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")


### PR DESCRIPTION
While I think `10%` is a good default, this may be too much or too little depending on the number of worker processes and how longthe `after_worker_fork` callbacks takes.