### PR TITLE
Abort if worker consistently can't be spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Implemented the `max_consecutive_spawn_errors` configuration. Purely opt-in for now.
+
 # 0.17.0
 
 - Improve `Pitchfork::Info#live_workers_count` to be more accurate.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -557,6 +557,22 @@ For instance `refork_max_unavailable 5` means 5 workers may be unavailable durin
 
 The default is `(workers_processes * 0.1).ceil`, or `10%` rounded up.
 
+### `max_consecutive_spawn_errors`
+
+```ruby
+max_consecutive_spawn_errors 5
+```
+
+Sets the number of consecutive failures of spawning new workers that trigger a shutdown.
+
+Whenever a newly spawned worker fail to acheive readiness, either because it crashes or because
+it times out before becoming ready, a counter is incremented. Whenever a worker successfully
+reach readiness, the counter is reset.
+
+This can be useful to better handle issues with slow or broken `after_worker_fork` callbacks.
+
+The default is `nil`, which means the behavior is disabled.
+
 ## Rack Features
 
 ### `early_hints`

--- a/lib/pitchfork/configurator.rb
+++ b/lib/pitchfork/configurator.rb
@@ -220,6 +220,10 @@ module Pitchfork
       set_int(:refork_max_unavailable, max, 1)
     end
 
+    def max_consecutive_spawn_errors(max)
+      set_int(:max_consecutive_spawn_errors, max, 1)
+    end
+
     def early_hints(bool)
       set_bool(:early_hints, bool)
     end

--- a/lib/pitchfork/message.rb
+++ b/lib/pitchfork/message.rb
@@ -124,6 +124,7 @@ module Pitchfork
   class Message
     SpawnWorker = new(:nr)
     WorkerSpawned = new(:nr, :pid, :generation, :pipe)
+    WorkerReady = new(:nr, :pid, :generation)
     PromoteWorker = new(:generation)
 
     MoldSpawned = new(:nr, :pid, :generation, :pipe)
@@ -131,6 +132,7 @@ module Pitchfork
 
     SpawnService = new(:_) # Struct.new requires at least 1 member on Ruby < 3.3
     ServiceSpawned = new(:pid, :generation, :pipe)
+    ServiceReady = new(:pid, :generation)
 
     SoftKill = new(:signum)
   end

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -343,8 +343,6 @@ class ReforkingTest < Pitchfork::IntegrationTest
       assert_stderr(/SUCCESS/)
 
       assert_clean_shutdown(pid)
-    ensure
-      puts read_stderr
     end
   end
 end


### PR DESCRIPTION
Users can put anything in `after_worker_fork` and can cause worker spawn to never succeed. Either because it's outright broken or because it became slow enough to timeout often.

In such case it's probably best to just abort, otherwise we may end up in an infinite loop of trying to spawn workers.
