### PR TITLE
Fix `before_worker_exit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix a regression introduced in `0.17.0` causing `before_worker_exit` to often not be called.
 - Implemented the `max_consecutive_spawn_errors` configuration. Purely opt-in for now.
 
 # 0.17.0

--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -1186,8 +1186,6 @@ module Pitchfork
     FORK_TIMEOUT = 5
 
     def fork_sibling(role, &block)
-      reset_signal_handlers
-
       if REFORKING_AVAILABLE
         r, w = Pitchfork::Info.keep_ios(IO.pipe)
         # We double fork so that the new worker is re-attached back
@@ -1211,6 +1209,8 @@ module Pitchfork
             raise ForkFailure, "fork_sibling didn't succeed in #{FORK_TIMEOUT} seconds"
           end
         else # first child
+          reset_signal_handlers
+
           r.close
           Process.setproctitle("<pitchfork fork_sibling(#{role})>")
           pid = Pitchfork.clean_fork(setpgid: setpgid) do

--- a/test/integration/test_reforking.rb
+++ b/test/integration/test_reforking.rb
@@ -11,6 +11,10 @@ class ReforkingTest < Pitchfork::IntegrationTest
         worker_processes 2
         refork_after [5, 5]
         refork_max_unavailable 1
+
+        before_worker_exit do |server, worker|
+          server.logger.info("clean_exit worker=\#{worker.nr}")
+        end
       CONFIG
 
       assert_healthy("http://#{addr}:#{port}")
@@ -23,6 +27,7 @@ class ReforkingTest < Pitchfork::IntegrationTest
 
       assert_stderr "refork condition met, promoting ourselves", timeout: 3
       assert_stderr "Terminating old mold gen=0 pid="
+      assert_stderr(/clean_exit worker=0/)
       assert_stderr(/worker=0 gen=1 pid=\d+ ready/)
       assert_stderr(/worker=1 gen=1 pid=\d+ ready/)
 


### PR DESCRIPTION
If we reset the handlers in the current process we are likely to get a second signal and bypass the exit hooks.

Fix: https://github.com/Shopify/pitchfork/issues/168