### PR TITLE
Ensure Rack config pragmas are kept during application building

### DIFF
--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -87,7 +87,12 @@ module Pitchfork
         when /\.ru$/
           raw = File.read(ru)
           raw.sub!(/^__END__\n.*/, '')
-          eval("Rack::Builder.new {(\n#{raw}\n)}.to_app", TOPLEVEL_BINDING, ru)
+          lines = raw.lines
+          trailing_comments_index = lines.index { |line| !line.start_with?('#') }
+          prelude = lines[0...trailing_comments_index].join
+          raw = lines[trailing_comments_index..-1].join
+
+          eval("#{prelude}\nRack::Builder.new do\n#{raw}\nend.to_app\n", TOPLEVEL_BINDING, ru)
         else
           require ru
           Object.const_get(File.basename(ru, '.rb').capitalize)

--- a/test/integration/frozen_string.ru
+++ b/test/integration/frozen_string.ru
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+run lambda { |_env|
+  if 'test'.frozen?
+    [200, {}, []]
+  else
+    [500, {}, []]
+  end
+}

--- a/test/integration/test_rack_pragmas.rb
+++ b/test/integration/test_rack_pragmas.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'integration_test_helper'
+
+class RackPragmasTest < Pitchfork::IntegrationTest
+  def test_keeps_rack_config_pragmas
+    addr, port = unused_port
+
+    pid = spawn_server("-E", "none", app: File.join(ROOT, "test/integration/frozen_string.ru"), lint: false, config: <<~CONFIG,)
+      listen "#{addr}:#{port}"
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+    assert_clean_shutdown(pid)
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/Shopify/pitchfork/issues/173

Prior to these changes, Ruby pragmas (including `frozen-string-literal`) were inserted in the wrong place.

This might be a breaking change.