### PR TITLE
Fix after_request_complete getting nil env

### DIFF
--- a/lib/pitchfork/http_server.rb
+++ b/lib/pitchfork/http_server.rb
@@ -1014,9 +1014,10 @@ module Pitchfork
             when Message
               worker.update(client)
             else
-              request_env = process_client(client, worker, prepare_timeout(worker))
-              worker.increment_requests_count
-              @after_request_complete&.call(self, worker, request_env)
+              if (request_env = process_client(client, worker, prepare_timeout(worker)))
+                worker.increment_requests_count
+                @after_request_complete&.call(self, worker, request_env)
+              end
             end
 
             worker.update_deadline(@timeout)

--- a/test/integration/test_parser_error.rb
+++ b/test/integration/test_parser_error.rb
@@ -121,4 +121,34 @@ class ParserErrorTest < Pitchfork::IntegrationTest
 
     assert_clean_shutdown(pid)
   end
+
+  def test_after_request_complete_receives_partial_env_on_error
+    addr, port = unused_port
+
+    pid = spawn_server(app: File.join(ROOT, "test/integration/env.ru"), config: <<~CONFIG)
+      listen "#{addr}:#{port}"
+
+      after_request_complete do |server, worker, env|
+        $stderr.puts "\#{env["REQUEST_METHOD"]}"
+      rescue
+        $stderr.puts "after_request_complete error"
+      end
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+
+    Socket.tcp(addr, port) do |sock|
+      sock.print("BAD")
+      sock.close_write
+    end
+
+    # run another request so we don't need to wait for a timeout
+    assert_equal "200", http_get("http://#{addr}:#{port}/").code
+
+    print_stderr_on_error do
+      refute_match("after_request_complete error", read_stderr)
+    end
+
+    assert_clean_shutdown(pid)
+  end
 end


### PR DESCRIPTION
Previously, when a request caused `@request.read(client)` to raise, `after_request_complete` callbacks would end up with a `nil` `env` (which can cause `NoMethodError`s when assuming its always a `Hash`).

~~This commit fixes the `NoMethodError` possibility by ensuring the `env` returned is at least a `Hash` so that `[]` won't raise. Note that it still can't be treated as a _valid_ Rack environment since the request wasn't able to finish parsing, but a `Hash` here is better than `nil`.~~

This commit fixes the `NoMethodError` possibility by only running the callback (and incrementing the request counter) if a valid environment was constructed.