### PR TITLE
Skip auto-inserting Rack::Lint on Rack 3+

### DIFF
--- a/lib/pitchfork.rb
+++ b/lib/pitchfork.rb
@@ -97,7 +97,18 @@ module Pitchfork
         Rack::Builder.new do
           use(Rack::ContentLength)
           use(Pitchfork::Chunked)
-          use(Rack::Lint) if ENV["RACK_ENV"] == "development"
+          # Rack 3 dropped `rewind` from the strict `rack.input` surface, so
+          # `Rack::Lint::Wrapper::InputWrapper` no longer exposes it. Rails
+          # middleware (cookies, body parsers) and third-party Rack middleware
+          # still call `request.body.rewind` (or read the body twice), so
+          # inserting `Rack::Lint` here in development silently breaks every
+          # body-bearing request the moment a config switches a dev `web:`
+          # process to Pitchfork. The dev-affordance value of Lint is no longer
+          # worth the trap on Rack 3+, so only auto-insert under Rack 2.
+          # See https://github.com/Shopify/pitchfork/issues/177.
+          if ENV["RACK_ENV"] == "development" && (!defined?(Rack::RELEASE) || Rack::RELEASE < "3")
+            use(Rack::Lint)
+          end
           use(Rack::TempfileReaper)
           run inner_app
         end.to_app

--- a/test/integration/test_rack_lint.rb
+++ b/test/integration/test_rack_lint.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'integration_test_helper'
+
+class RackLintTest < Pitchfork::IntegrationTest
+  # `fails-rack-lint.ru` returns a header named "status", which Rack::Lint
+  # rejects with a 500. On Rack 3+, Pitchfork no longer auto-inserts Rack::Lint
+  # (it drops `rewind` from `rack.input` in a way that breaks Rails middleware,
+  # see https://github.com/Shopify/pitchfork/issues/177), so the response should
+  # come back from the app unchanged.
+  def test_no_auto_rack_lint_on_rack_3
+    skip("Only relevant on Rack 3+") unless defined?(Rack::RELEASE) && Rack::RELEASE >= "3"
+
+    addr, port = unused_port
+
+    # lint: true keeps the default RACK_ENV (which the Pitchfork CLI sets to
+    # "development"). On Rack 2 this would inject Rack::Lint and the request
+    # below would 500; on Rack 3+ the gate skips the insert and the app's body
+    # comes through.
+    pid = spawn_server(app: File.join(ROOT, "test/integration/fails-rack-lint.ru"), lint: true, config: <<~CONFIG)
+      listen "#{addr}:#{port}"
+    CONFIG
+
+    assert_healthy("http://#{addr}:#{port}")
+
+    response = Net::HTTP.get_response(URI("http://#{addr}:#{port}"))
+    assert_equal 200, response.code.to_i
+    assert_equal "Rack::Lint wasn't there if you see this", response.body.strip
+
+    assert_clean_shutdown(pid)
+  end
+end


### PR DESCRIPTION
### Problem

Pitchfork's default app builder injects `Rack::Lint` into the middleware stack whenever `RACK_ENV == "development"`:

https://github.com/Shopify/pitchfork/blob/v0.18.2/lib/pitchfork.rb#L100

Combined with `exe/pitchfork:7`'s `ENV["RACK_ENV"] ||= "development"`, this means *every* Pitchfork process that didn't explicitly set `RACK_ENV` ends up with `Rack::Lint` in its stack.

On Rack 3, `Rack::Lint::Wrapper::InputWrapper` no longer exposes `rewind` (it was dropped from the strict spec). Rails middleware and most third-party Rack middleware still call `request.body.rewind` unconditionally, so any Rails dev process that switches from Puma to Pitchfork starts 500ing on every cookie- or body-bearing request:

```
undefined method 'rewind' for an instance of Rack::Lint::Wrapper::InputWrapper
```

This is #177 — the linked issue documents one observable failure (`request.raw_post` returns nil via `Rack::MethodOverride` exhausting the stream, then `ActionDispatch::Request#reset_stream` can't rewind). We hit it in a different shape: `ActionDispatch::Cookies` and third-party analytics middleware call `rewind` directly without `respond_to?(:rewind)` guards, so the failure happens before any controller runs, and the entire Rails GraphQL surface goes dark in dev.

### Fix

Gate the auto-insert on `Rack::RELEASE < "3"`. Rack 2 users keep the existing dev affordance. Rack 3 users stop tripping over the incompatibility.

The integration test uses the existing `test/integration/fails-rack-lint.ru` fixture (which returns a response header that `Rack::Lint` would 500 on). With `lint: true` (the spawn_server default — RACK_ENV stays at the CLI's "development" default), the test asserts the response comes through unchanged on Rack 3+, which is only true if the gate kept `Rack::Lint` out.

### Alternatives considered

Issue #177 surfaced three other options, none of which I picked:

- **Drop `ENV["RACK_ENV"] ||= "development"` in `exe/pitchfork`.** Cleanest from a Rails-convention standpoint (RAILS_ENV is the canonical source), but it's a behavior change for *every* Pitchfork user, not just Rack 3+ users, and it's load-bearing for the dev affordances on Rack 2.
- **Replace `Rack::Lint` with a custom validator that delegates `rewind` to the underlying input.** More invasive, more code to maintain, and it leaks lint-spec violations of the rest of the spec we don't want to swallow.
- **Force users to set `RACK_ENV=production` (or equivalent) themselves.** This is the workaround the issue lands on, but it's surprising — the trap fires the moment someone runs `bin/pitchfork` without reading the issue thread first.

The Rack-version gate is the minimum change that removes the trap for the affected users without changing anything for the unaffected ones. Happy to take it in a different direction if you'd prefer one of the alternatives.

### Notes

- Existing tests that explicitly opt out via `lint: false` (which sets `RACK_ENV=production` in the spawned process) are unaffected.
- The single existing test that depends on Lint's strict behavior (`test/integration/fails-rack-lint.ru` is referenced only as a fixture; no test references it yet) is now covered by the new test — but only for the "Rack::Lint is *not* there" direction, which is what this PR introduces.
