### PR TITLE
Check child subreaper support at runtime (not just at compile-time)

### DIFF
--- a/ext/pitchfork_http/child_subreaper.h
+++ b/ext/pitchfork_http/child_subreaper.h
@@ -3,6 +3,10 @@
 #include <sys/prctl.h>
 
 static VALUE enable_child_subreaper(VALUE module) {
+  int status = -1;
+  if (prctl(PR_GET_CHILD_SUBREAPER, &status) < 0) {
+    return Qfalse;
+  }
   if (prctl(PR_SET_CHILD_SUBREAPER, 1) < 0) {
     rb_sys_fail("prctl(2) PR_SET_CHILD_SUBREAPER");
   }
@@ -17,7 +21,9 @@ static VALUE enable_child_subreaper(VALUE module) {
 void init_child_subreaper(VALUE mPitchfork)
 {
 #ifdef HAVE_CONST_PR_SET_CHILD_SUBREAPER
-  rb_define_const(mPitchfork, "CHILD_SUBREAPER_AVAILABLE", Qtrue);
+  int status = -1;
+  int ret = prctl(PR_GET_CHILD_SUBREAPER, &status);
+  rb_define_const(mPitchfork, "CHILD_SUBREAPER_AVAILABLE", ret < 0 ? Qfalse : Qtrue);
 #else
   rb_define_const(mPitchfork, "CHILD_SUBREAPER_AVAILABLE", Qfalse);
 #endif


### PR DESCRIPTION
On some systems (e.g. Debian running under [OmniOS/SmartOS LX](https://omnios.org/info/lxzones)), the `PR_SET_CHILD_SUBREAPER` constant is defined in the system headers, but the corresponding syscall is not implemented.  On those systems, Pitchfork aborts with this error message:
```
/opt/ruby3.4/lib/ruby/gems/3.4.0/gems/pitchfork-0.18.2/lib/pitchfork/http_server.rb:159:in 'Pitchfork.enable_child_subreaper': Invalid argument - prctl(2) PR_SET_CHILD_SUBREAPER (Errno::EINVAL)
```

In this PR, I've changed Pitchfork to first try to _get_ the child subreaper attribute, then (1) populate the `CHILD_SUBREAPER_AVAILABLE` constant with the result of that check, and (2) only attempt to _set_ the child subreaper attribute if the prior _get_ succeeded.  This enables Pitchfork to run under OmniOS/SmartOS LX.