### PR TITLE
Upgrade CI runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     env:
       RACK_VERSION: "${{ matrix.rack }}"
       RUBYOPT: "${{ matrix.rubyopt }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
- `ubuntu-22.04` hosted runners begin deprecation on 2026-09-17 and will be fully unsupported by 2027-04-17
  -  actions/runner-images#14254
