### PR TITLE
Speed up http_response_write's hot path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ end
 
 group :benchmark do
   gem "puma"
+  gem "stackprof"
+  gem "benchmark-ips"
 end
 
 gemspec

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -30,3 +30,20 @@ The `constant_caches.ru` application is specifically crafted to demonstrate how 
 get invalidated as applications execute more and more code.
 
 It is an extreme example for benchmark purposes.
+
+## Request processing throughput
+
+`request_benchmark.rb` benchmarks the per-request Ruby-level hot path (HTTP parsing and
+response writing) over a socket pair, without the noise of a real TCP stack or listener loop:
+
+```bash
+$ bundle exec benchmark/request_benchmark.rb
+process request (parse+respond)    125.745k (± 2.9%) i/s    (7.95 μs/i)
+```
+
+Pass `profile` (and optionally an iteration count) to capture a StackProf wall-clock profile instead:
+
+```bash
+$ bundle exec benchmark/request_benchmark.rb profile
+$ bundle exec stackprof benchmark/stackprof-request_benchmark.dump --text
+```

--- a/benchmark/request_benchmark.rb
+++ b/benchmark/request_benchmark.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Benchmarks the per-request Ruby-level hot path: HTTP parsing
+# (Pitchfork::HttpParser#read) and response writing (http_response_write).
+# This isolates the part of a request pitchfork controls in Ruby, without
+# the noise of a real TCP stack, listener accept loop, or a Rack app.
+#
+# Usage:
+#   bundle exec benchmark/request_benchmark.rb            # benchmark-ips report
+#   bundle exec benchmark/request_benchmark.rb profile N   # StackProf wall-clock profile, N iterations (default 200_000)
+require "socket"
+require "benchmark/ips"
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "pitchfork"
+
+REQUEST = "GET /hello?foo=bar HTTP/1.1\r\nHost: example.com\r\nUser-Agent: bench\r\nAccept: */*\r\nConnection: close\r\n\r\n".b
+
+class RequestBench
+  include Pitchfork::HttpResponse
+
+  def initialize
+    @client, @server = Socket.pair(:UNIX, :STREAM, 0)
+  end
+
+  def run_once
+    @client.write(REQUEST)
+    req = Pitchfork::HttpParser.new
+    env = req.read(@server)
+    body = "Hello World!\n"
+    headers = { "content-type" => "text/plain", "content-length" => body.bytesize.to_s }
+    http_response_write(@server, 200, headers, [body], req)
+    @client.readpartial(65536)
+    env
+  end
+end
+
+bench = RequestBench.new
+env = bench.run_once
+raise "sanity check failed" unless env["PATH_INFO"] == "/hello"
+
+if ARGV[0] == "profile"
+  require "stackprof"
+  n = (ARGV[1] || 200_000).to_i
+  out = File.join(__dir__, "stackprof-request_benchmark.dump")
+  StackProf.run(mode: :wall, out: out, raw: true) do
+    n.times { bench.run_once }
+  end
+  puts "wrote #{out}, inspect with: bundle exec stackprof #{out} --text"
+else
+  Benchmark.ips do |x|
+    x.report("process request (parse+respond)") { bench.run_once }
+  end
+end

--- a/lib/pitchfork/http_response.rb
+++ b/lib/pitchfork/http_response.rb
@@ -30,11 +30,18 @@ module Pitchfork
           next if ILLEGAL_HEADER_VALUE.match?(v)
           buf << "#{key}: #{v}\r\n"
         end
-      when /\n/ # Rack 2
-        # avoiding blank, key-only cookies with /\n+/
-        value.split(/\n+/).each do |v|
-          next if ILLEGAL_HEADER_VALUE.match?(v)
-          buf << "#{key}: #{v}\r\n"
+      when String
+        if value.include?("\n") # Rack 2
+          # avoiding blank, key-only cookies with /\n+/
+          value.split(/\n+/).each do |v|
+            next if ILLEGAL_HEADER_VALUE.match?(v)
+            buf << key << ": " << v << "\r\n"
+          end
+        else
+          # Common case: a single-line string value, the vast majority of
+          # headers. Appending directly avoids the intermediate string
+          # allocation that string interpolation would create.
+          buf << key << ": " << value << "\r\n"
         end
       else
         buf << "#{key}: #{value}\r\n"
@@ -54,10 +61,12 @@ module Pitchfork
               "Date: #{httpdate}\r\n" \
               "Connection: close\r\n".b
         headers.each do |key, value|
-          case key
-          when %r{\A(?:Date|Connection)\z}i
-            next
-          when "rack.hijack"
+          # Fast path: skip the case-insensitive Date/Connection check without
+          # a regexp for every other header (the vast majority).
+          next if (key.length == 4 && key.casecmp?("date")) ||
+                  (key.length == 10 && key.casecmp?("connection"))
+
+          if key == "rack.hijack"
             # This should only be hit under Rack >= 1.5, as this was an illegal
             # key in Rack < 1.5
             hijack = value

--- a/lib/pitchfork/http_response.rb
+++ b/lib/pitchfork/http_response.rb
@@ -65,15 +65,37 @@ module Pitchfork
             append_header(buf, key, value)
           end
         end
-        socket.write(buf << "\r\n")
+        buf << "\r\n"
       end
 
       if hijack
+        socket.write(buf) if buf
         req.hijacked!
         hijack.call(socket)
       elsif body.respond_to?(:each)
-        body.each { |chunk| socket.write(chunk) }
+        # Combine the header block with the first body chunk into a single
+        # write (backed by writev(2) when supported) to save a syscall on
+        # the common case of a response with a single body chunk.
+        #
+        # `buf` itself (rather than a separate flag) is the "already sent"
+        # sentinel: some bodies (e.g. ones that defer emitting via #close)
+        # capture the block passed to #each and invoke it again later, so
+        # the sentinel must be a value the closure observes being mutated,
+        # not a value captured at closure-creation time.
+        body.each do |chunk|
+          if buf
+            socket.write(buf, chunk)
+            buf = nil
+          else
+            socket.write(chunk)
+          end
+        end
+        if buf
+          socket.write(buf)
+          buf = nil
+        end
       else
+        socket.write(buf) if buf
         body.call(socket)
       end
     end


### PR DESCRIPTION
`http_response_write` runs on the hot path of every request that isn't
fully hijacked or an app/parse error, so I put together
`benchmark/request_benchmark.rb` (a socket-pair benchmark exercising
`HttpParser#read` + `http_response_write` without a real network stack)
and profiled it with stackprof.

The first commit combines the header block and the first body chunk into
a single `socket.write` call (writev(2)-backed) instead of two, for the
common case of a single-chunk response body. There's a subtlety around
bodies that defer emitting via `#close` (see
`test/integration/apps/write-on-close.ru`), explained in the commit
message.

The second commit replaces two per-header regexp matches - the
`Date`/`Connection` skip check and `append_header`'s Rack 2 multi-line-value
detection - with a length-gated `casecmp?` and a plain `String#include?`.

No behavior change intended. Each commit message has its own before/after
numbers.

Benchmarks, `bundle exec benchmark/request_benchmark.rb` (parse + respond
over a socket pair):

    before:          109k i/s
    after commit 1:  120k i/s (+10%)
    after commit 2:  126k i/s (+16% cumulative)

Real server (`examples/hello.ru`, 4 workers), `ab -n 20000 -c 50`, 10 rounds
alternating start order, before vs. after both commits:

    mean req/s:   26282 -> 28509 (+8.5%)
    median req/s: 25855 -> 29618 (+14.5%)

after won 9/10 rounds, 0 failed requests throughout.

Test plan:
- `bundle exec rake test:unit`
- `bundle exec rake test:integration`
- Manually verified plain request/response, chunked multi-chunk streaming
  body (`examples/echo.ru`), partial response hijack, and a nil header
  value