### PR TITLE
Default to `RACK_ENV=production` instead of development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `RACK_ENV` now default to `"production"` instead of `"development"`.
+
 # 0.18.2
 
 - Fix after_request_complete getting nil env on parsing exceptions.

--- a/exe/pitchfork
+++ b/exe/pitchfork
@@ -4,7 +4,7 @@
 require 'pitchfork/launcher'
 require 'optparse'
 
-ENV["RACK_ENV"] ||= "development"
+ENV["RACK_ENV"] ||= "production"
 rackup_opts = Pitchfork::Configurator::RACKUP
 options = rackup_opts[:options]
 
@@ -55,7 +55,7 @@ op = OptionParser.new("", 24, '  ') do |opts|
   end
 
   opts.on("-E", "--env RACK_ENV",
-          "use RACK_ENV for defaults (default: development)") do |e|
+          "use RACK_ENV for defaults (default: production)") do |e|
     ENV["RACK_ENV"] = e
   end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -181,7 +181,7 @@ module Pitchfork
 
     def spawn_server(*args, app:, config:, lint: true)
       File.write("pitchfork.conf.rb", config)
-      env = lint ? {} : { "RACK_ENV" => "production" }
+      env = { "RACK_ENV" => lint ? "development" : "production" }
       spawn(env, BIN, app, "-c", "pitchfork.conf.rb", *args)
     end
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/pitchfork/pull/183
Fix: https://github.com/Shopify/pitchfork/issues/177

Otherwise it's too easy to mistakenly enable rack linting in production.